### PR TITLE
Top level enums

### DIFF
--- a/jtd_to_proto/descriptor_to_message_class.py
+++ b/jtd_to_proto/descriptor_to_message_class.py
@@ -72,4 +72,12 @@ def descriptor_to_message_class(
         nested_message_class = descriptor_to_message_class(nested_message_descriptor)
         setattr(message_class, nested_message_descriptor.name, nested_message_class)
 
+    # Recursively add nested enums
+    for nested_enum_descriptor in descriptor.enum_types:
+        setattr(
+            message_class,
+            nested_enum_descriptor.name,
+            descriptor_to_message_class(nested_enum_descriptor),
+        )
+
     return message_class

--- a/jtd_to_proto/descriptor_to_message_class.py
+++ b/jtd_to_proto/descriptor_to_message_class.py
@@ -4,30 +4,38 @@ Descriptor objects
 """
 
 # Standard
-from typing import Type
+from typing import Type, Union
 import os
 
 # Third Party
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection
+from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 
 # Local
 from .descriptor_to_file import descriptor_to_file
 
 
 def descriptor_to_message_class(
-    descriptor: _descriptor.Descriptor,
-) -> Type[_message.Message]:
+    descriptor: Union[_descriptor.Descriptor, _descriptor.EnumDescriptor],
+) -> Union[Type[_message.Message], EnumTypeWrapper]:
     """Create the proto class from the given descriptor
 
     Args:
-        descriptor:  descriptor.Descriptor
-            The message Desscriptor
+        descriptor:  Union[_descriptor.Descriptor, _descriptor.EnumDescriptor]
+            The message or enum Descriptor
 
     Returns:
-        message_class:  Type[message.Message]
+        generated:  Union[Type[_message.Message], EnumTypeWrapper]
+            The generated message class or the enum wrapper
     """
+    # Handle enum descriptors
+    if isinstance(descriptor, _descriptor.EnumDescriptor):
+        return EnumTypeWrapper(descriptor)
+
+    # Handle message descriptors
+
     message_class = reflection.message_factory.MessageFactory().GetPrototype(descriptor)
 
     # Add to_proto_file

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -3,7 +3,7 @@ Tests for the jtd_to_proto logic
 """
 
 # Third Party
-from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.descriptor import EnumDescriptor, FieldDescriptor
 import pytest
 
 # Local
@@ -205,6 +205,20 @@ def test_jtd_to_proto_enum(temp_dpool):
     assert list(fields.keys()) == ["bat"]
     assert fields["bat"].type == fields["bat"].TYPE_ENUM
     assert fields["bat"].label == fields["bat"].LABEL_OPTIONAL
+
+
+def test_jtd_to_proto_top_level_enum(temp_dpool):
+    """Ensure that enums can be converted"""
+    msg_name = "Foo"
+    package = "foo.bar"
+    descriptor = jtd_to_proto(
+        msg_name,
+        package,
+        {"enum": ["VAMPIRE", "DRACULA"]},
+        descriptor_pool=temp_dpool,
+        validate_jtd=True,
+    )
+    assert isinstance(descriptor, EnumDescriptor)
 
 
 def test_jtd_to_proto_arrays_of_primitives(temp_dpool):


### PR DESCRIPTION
## Description

Closes #7 

This PR adds support for top-level JTD enum schemas and converting them to `EnumTypeWrapper` to match the behavior of compiled protobuf python modules.