### PR TITLE
Enum refs 18

### DIFF
--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -124,7 +124,7 @@ def jtd_to_proto(
         name=f"{name.lower()}.proto",
         package=package,
         syntax="proto3",
-        dependency=imports,
+        dependency=sorted(list(set(imports))),
         **proto_kwargs,
     )
     log.debug4("Full FileDescriptorProto:\n%s", fd_proto)

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -1,5 +1,5 @@
 # Standard
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 import copy
 import re
 
@@ -156,7 +156,7 @@ def _jtd_to_proto_impl(
     descriptor_pb2.DescriptorProto,
     descriptor_pb2.EnumDescriptorProto,
     int,
-    str,
+    Tuple[str, int],
 ]:
     """Recursive implementation of converting messages, fields, enums, arrays,
     and maps from JTD to their respective *DescriptorProto representations.
@@ -172,7 +172,11 @@ def _jtd_to_proto_impl(
     if type_name is not None:
         # If the type name is itself a descriptor, use it as the value directly
         proto_type_descriptor = None
+        is_enum = False
         if isinstance(type_name, _descriptor.Descriptor):
+            proto_type_descriptor = type_name
+        elif isinstance(type_name, _descriptor.EnumDescriptor):
+            is_enum = True
             proto_type_descriptor = type_name
         else:
             proto_type_val = JTD_TO_PROTO_TYPES.get(type_name)
@@ -196,7 +200,14 @@ def _jtd_to_proto_impl(
             type_name,
         )
         imports.append(import_file)
-        return type_name
+        return (
+            type_name,
+            (
+                _descriptor.FieldDescriptor.TYPE_ENUM
+                if is_enum
+                else _descriptor.FieldDescriptor.TYPE_MESSAGE
+            ),
+        )
 
     # If the definition has "enum" it's an enum
     enum = jtd_def.get("enum")
@@ -343,12 +354,12 @@ def _jtd_to_proto_impl(
                 if isinstance(nested, int):
                     nested_field_kwargs["type"] = nested
 
-                # If the result is a tuple, it's an imported message name
-                elif isinstance(nested, str):
-                    nested_field_kwargs[
-                        "type"
-                    ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
-                    nested_field_kwargs["type_name"] = nested
+                # If the result is a tuple, it's an imported message or name
+                elif isinstance(nested, tuple):
+                    (
+                        nested_field_kwargs["type_name"],
+                        nested_field_kwargs["type"],
+                    ) = nested
 
                 # If the result is an enum, add it as a nested enum
                 elif isinstance(nested, descriptor_pb2.EnumDescriptorProto):

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -615,6 +615,26 @@ def test_jtd_to_proto_reference_external_descriptor(temp_dpool):
     assert wrapper_descriptor.fields_by_name["bar"].message_type is nested_descriptor
 
 
+def test_jtd_to_proto_reference_external_enum_descriptor(temp_dpool):
+    """Test that values in the JTD schema can be references to other in-memory
+    enum descriptors
+    """
+
+    enum_descriptor = jtd_to_proto(
+        "Foo",
+        "foo.bar",
+        {"enum": ["FOO", "BAR"]},
+        descriptor_pool=temp_dpool,
+    )
+    wrapper_descriptor = jtd_to_proto(
+        "Bar",
+        "foo.bar",
+        {"properties": {"bar": {"type": enum_descriptor}}},
+        descriptor_pool=temp_dpool,
+    )
+    assert wrapper_descriptor.fields_by_name["bar"].enum_type is enum_descriptor
+
+
 def test_jtd_to_proto_bytes(temp_dpool):
     """Make sure that fields can have type bytes and that the messages can be
     validated even with bytes which is not in the JTD spec

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -568,7 +568,7 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
     assert fields["metoo"].label == fields["metoo"].LABEL_OPTIONAL
 
 
-def test_jtd_to_proto_top_level_enum():
+def test_jtd_to_proto_top_level_enum(temp_dpool):
     """Make sure that a top-level enum can be converted
 
     NOTE: This test also validates the use of the default descriptor pool
@@ -579,6 +579,7 @@ def test_jtd_to_proto_top_level_enum():
         msg_name,
         package,
         {"enum": ["FOO", "BAR"]},
+        descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
     # Validate message naming
@@ -594,21 +595,27 @@ def test_jtd_to_proto_top_level_enum():
     }
 
 
-def test_jtd_to_proto_reference_external_descriptor():
+def test_jtd_to_proto_reference_external_descriptor(temp_dpool):
     """Test that values in the JTD schema can be references to other in-memory
     descriptors
     """
 
     nested_descriptor = jtd_to_proto(
-        "Foo", "foo.bar", {"properties": {"foo": {"type": "string"}}}
+        "Foo",
+        "foo.bar",
+        {"properties": {"foo": {"type": "string"}}},
+        descriptor_pool=temp_dpool,
     )
     wrapper_descriptor = jtd_to_proto(
-        "Bar", "foo.bar", {"properties": {"bar": {"type": nested_descriptor}}}
+        "Bar",
+        "foo.bar",
+        {"properties": {"bar": {"type": nested_descriptor}}},
+        descriptor_pool=temp_dpool,
     )
     assert wrapper_descriptor.fields_by_name["bar"].message_type is nested_descriptor
 
 
-def test_jtd_to_proto_bytes():
+def test_jtd_to_proto_bytes(temp_dpool):
     """Make sure that fields can have type bytes and that the messages can be
     validated even with bytes which is not in the JTD spec
     """
@@ -616,13 +623,14 @@ def test_jtd_to_proto_bytes():
         "HasBytes",
         "foo.bar",
         {"properties": {"foo": {"type": "bytes"}}},
+        descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
     bytes_field = bytes_descriptor.fields_by_name["foo"]
     assert bytes_field.type == bytes_field.TYPE_BYTES
 
 
-def test_jtd_to_proto_int64():
+def test_jtd_to_proto_int64(temp_dpool):
     """Make sure that fields can have type int64 and that the messages can be
     validated.
     """
@@ -630,13 +638,14 @@ def test_jtd_to_proto_int64():
         "HasInt64",
         "foo.bar",
         {"properties": {"foo": {"type": "int64"}}},
+        descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
     int64_field = int64_descriptor.fields_by_name["foo"]
     assert int64_field.type == int64_field.TYPE_INT64
 
 
-def test_jtd_to_proto_uint64():
+def test_jtd_to_proto_uint64(temp_dpool):
     """Make sure that fields can have type uint64 and that the messages can be
     validated.
     """
@@ -644,10 +653,28 @@ def test_jtd_to_proto_uint64():
         "HasUInt64",
         "foo.bar",
         {"properties": {"foo": {"type": "uint64"}}},
+        descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
     uint64_field = uint64_descriptor.fields_by_name["foo"]
     assert uint64_field.type == uint64_field.TYPE_UINT64
+
+
+def test_jtd_to_proto_default_dpool():
+    """This test ensures that without an explicitly passed descriptor pool, the
+    default is used. THIS SHOULD BE THE ONLY TEST THAT DOESN'T USE `temp_dpool`!
+    """
+    jtd_to_proto(
+        "Foo",
+        "foo.bar",
+        {
+            "properties": {
+                "foo": {
+                    "type": "boolean",
+                },
+            }
+        },
+    )
 
 
 ## Error Cases #################################################################


### PR DESCRIPTION
## Description

Closes #18 

This PR mimics #4 and adds support for using in-memory references to `EnumDescriptor`s to reference pre-existing enums. With the addition of enums, the recursive interactions for the "fields" and "type" sections of `_jtd_to_proto_impl` got a little more complex. Previously, for imported types, only the name was returned and it was assumed to be `TYPE_MESSAGE`. Now, it needs to distinguish between `TYPE_MESSAGE` and `TYPE_ENUM`, so the return from the "type" section is a tuple of the `(str, int)` for the `(name, type)`.