### PR TITLE
:bug: Fix client stub output descriptor

### DIFF
--- a/jtd_to_proto/json_to_service.py
+++ b/jtd_to_proto/json_to_service.py
@@ -249,7 +249,7 @@ def _get_rpc_methods(service_descriptor: ServiceDescriptor) -> List[_RPCMethod]:
         method: _descriptor.MethodDescriptor
 
         input_descriptor: _descriptor.Descriptor = method.input_type
-        output_descriptor: _descriptor.Descriptor = method.input_type
+        output_descriptor: _descriptor.Descriptor = method.output_type
 
         input_message_class = descriptor_to_message_class(input_descriptor)
         output_message_class = descriptor_to_message_class(output_descriptor)


### PR DESCRIPTION
Fix output descriptor type of generated client stub and update the e2e test to check for a different output type

Affects registration function on servicer, etc. as well