### PR TITLE
Fix message collision check

### DIFF
--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -84,7 +84,8 @@ def _have_enum_alignment(
     for enum_name in d1_enum_descs.keys():
         d1_enum_descriptor = d1_enum_descs[enum_name]
         d2_enum_descriptor = d2_enum_descs[enum_name]
-        assert len(d1_enum_descriptor.value) == len(d2_enum_descriptor.value)
+        if len(d1_enum_descriptor.value) != len(d2_enum_descriptor.value):
+            return False
         # Compare each entry in the repeated composite container,
         # i.e., all of our EnumValueDescriptorProto objects
         for first_enum_val, second_enum_val in zip(

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -160,15 +160,12 @@ def _are_same_message_descriptor(
     if not d1_field_descs.keys() == d2_field_descs.keys():
         return False
     for field_name in d1_field_descs.keys():
-        # We consider two fields equal if they have the same name, label, type, and type_name
+        # We consider two fields equal if they have the same name, label
         d1_field_descriptor = d1_field_descs[field_name]
         d2_field_descriptor = d2_field_descs[field_name]
         if (
             d1_field_descriptor.label != d2_field_descriptor.label
             or d1_field_descriptor.type != d2_field_descriptor.type
-            or not _have_same_type_name(
-                d1_field_descriptor.type_name, d2_field_descriptor.type_name
-            )
         ):
             return False
     # For nested fields, we treat them similarly to how we've treated messages
@@ -177,39 +174,6 @@ def _are_same_message_descriptor(
         return _check_message_descs_alignment(d1.nested_type, d2.nested_type)
     # Otherwise, we have no more nested layers to check; we're done!
     return True
-
-
-def _have_same_type_name(d1_type_name: str, d2_type_name: str) -> bool:
-    """Check to see if two type_name fields are the same (probably). We need to be very careful
-    about this, because in some situations, we make be comparing a fully qualified type_name to
-    a type_name that is NOT fully qualified. To check this, we basically check that:
-
-    1. If they're the same, we're happy
-    2. If they're the same length and different, we're sad
-    3. If one is longer than the other, if the longer starts with a period, indicating a fully
-       qualified path, and its suffix is the shorter one, which doesn't start with a period,
-       we're happy
-    4. Otherwise we're sad
-
-    Args:
-        d1_type_name: str
-            type_name from first field descriptor.
-        d2_type_name: str
-            type_name from second field descriptor.
-
-    Returns:
-        bool
-            True if the two field descriptor type names passed are equivalent, False otherwise.
-    """
-    if d1_type_name == d2_type_name:
-        return True
-    if len(d2_type_name) > len(d1_type_name):
-        d2_type_name, d1_type_name = d1_type_name, d2_type_name
-    return (
-        d1_type_name.startswith(".")
-        and d1_type_name.endswith(d2_type_name)
-        and not d2_type_name.startswith(".")
-    )
 
 
 ## Globals #####################################################################

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -296,7 +296,13 @@ def jtd_to_proto(
         # Raise if the file exists already with different content
         # Otherwise, do not attempt to re-add the file
         if not _are_same_file_descriptors(fd_proto, existing_proto):
-            raise ValueError(
+            # NOTE: This is a TypeError because that is what you get most of the time when you
+            # have conflict issues in the descriptor pool arising from JTD to Proto followed by
+            # importing differing defs for the same top level message type using different file
+            # names (i.e., skipping this validation) compiled by protoc. Raising TypeError here
+            # ensures that we at least usually raise the same error type regardless of
+            # import / operation order.
+            raise TypeError(
                 f"Cannot add new file {fd_proto.name} to descriptor pool, file already exists with different content"
             )
     except KeyError:

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -41,6 +41,7 @@ def _are_same_file_descriptors(
             First FileDescriptorProto we want to compare.
         d2: descriptor_pb2.FileDescriptorProto
             second FileDescriptorProto we want to compare.
+
     Returns:
         True if the provided file descriptor proto files are identical.
     """
@@ -71,6 +72,7 @@ def _have_enum_alignment(
             First FileDescriptorProto we want to compare.
         d2: descriptor_pb2.FileDescriptorProto
             second FileDescriptorProto we want to compare.
+
     Returns:
         True if the provided file descriptor proto files are identical.
     """
@@ -177,7 +179,7 @@ def _are_same_message_descriptor(
     return True
 
 
-def _have_same_type_name(d1_type_name: str, d2_type_name: str):
+def _have_same_type_name(d1_type_name: str, d2_type_name: str) -> bool:
     """Check to see if two type_name fields are the same (probably). We need to be very careful
     about this, because in some situations, we make be comparing a fully qualified type_name to
     a type_name that is NOT fully qualified. To check this, we basically check that:
@@ -194,6 +196,7 @@ def _have_same_type_name(d1_type_name: str, d2_type_name: str):
             type_name from first field descriptor.
         d2_type_name: str
             type_name from second field descriptor.
+
     Returns:
         bool
             True if the two field descriptor type names passed are equivalent, False otherwise.

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -105,7 +105,7 @@ def _check_message_descs_alignment(
     """Determine if two message descriptor proto containers, i.e., RepeatedCompositeContainers
     have the same message types. This means the following:
 
-    1. the messages contained in each FileDescriptorProto are the same.
+    1. The messages contained in each FileDescriptorProto are the same.
     2. For each of those respective messages, their respective fields are roughly the same.
        Note that this includes nested_types, which are verified recursively.
 
@@ -123,9 +123,9 @@ def _check_message_descs_alignment(
     d2_msg_descs = {msg.name: msg for msg in d2_msg_container}
 
     # Ensure that our descriptors have the same dependencies & top level message types
-    if not d1_msg_descs.keys() == d2_msg_descs.keys():
+    if d1_msg_descs.keys() != d2_msg_descs.keys():
         return False
-    # For every encapsulated message descriptor, ensure that ever field has the same
+    # For every encapsulated message descriptor, ensure that every field has the same
     # name, number, label, type, and type name
     for msg_name in d1_msg_descs.keys():
         d1_message_descriptor = d1_msg_descs[msg_name]
@@ -158,7 +158,7 @@ def _are_same_message_descriptor(
     # Make sure all of our named fields align, then check them individually
     d1_field_descs = {field.name: field for field in d1.field}
     d2_field_descs = {field.name: field for field in d2.field}
-    if not d1_field_descs.keys() == d2_field_descs.keys():
+    if d1_field_descs.keys() != d2_field_descs.keys():
         return False
     for field_name in d1_field_descs.keys():
         # We consider two fields equal if they have the same name, label

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -33,7 +33,7 @@ def _to_upper_camel(snake_str: str) -> str:
 def _are_same_file_descriptors(
     d1: descriptor_pb2.FileDescriptorProto, d2: descriptor_pb2.FileDescriptorProto
 ) -> bool:
-    """Recursively validate that there are no consistency issues in the message descriptors of
+    """Validate that there are no consistency issues in the message descriptors of
     our proto file descriptors.
 
     Args:

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -887,6 +887,30 @@ def test_jtd_to_proto_duplicate_message_name(temp_dpool):
         )
 
 
+def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
+    """Check that we cannot register a different message with the same name with wrong enum vals"""
+    msg_name = "Foo"
+    package = "foo.bar"
+    # The respective values we are going to register
+    first_enum_values = ["Hello", "World"]
+    second_enum_values = ["Hi", "Planet"]
+    jtd_to_proto(
+        msg_name,
+        package,
+        {"enum": first_enum_values},
+        descriptor_pool=temp_dpool,
+        validate_jtd=True,
+    )
+    with pytest.raises(ValueError):
+        jtd_to_proto(
+            msg_name,
+            package,
+            {"enum": second_enum_values},
+            descriptor_pool=temp_dpool,
+            validate_jtd=True,
+        )
+
+
 ## Details #####################################################################
 
 

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -911,8 +911,8 @@ def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
         )
 
 
-def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
-    """Check that we cannot register a different message with the same name with wrong enum vals"""
+def test_jtd_to_proto_duplicate_enum_name_different_length(temp_dpool):
+    """Check that we cannot register a different message with the same name & different enum len"""
     msg_name = "Foo"
     package = "foo.bar"
     # The respective values we are going to register

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -798,6 +798,20 @@ def test_type_names_are_fully_qualified_with_multiple_packages(temp_dpool):
     assert foo_dproto.field[0].type_name == ".barpackage.Bar"
 
 
+def test_protoc_collision_same_def(temp_dpool):
+    """Test that if we do jtd_to_proto -> protoc with the same underlying file name, it is okay."""
+    # Happy because the file is named outermessage.proto, so we can find it!
+    protoc_sample = b'\n\x12outermessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    jtd_to_proto(
+        name="OuterMessage",
+        package="test.jtd_to_proto",
+        jtd_def={"properties": {"primitive": {"type": "string"}}},
+        validate_jtd=True,
+        descriptor_pool=temp_dpool,
+    )
+    temp_dpool.AddSerializedFile(protoc_sample)
+
+
 ## Error Cases #################################################################
 
 
@@ -871,7 +885,7 @@ def test_jtd_to_proto_duplicate_message_name(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -901,7 +915,7 @@ def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -925,7 +939,7 @@ def test_jtd_to_proto_duplicate_enum_name_different_length(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -961,7 +975,7 @@ def test_jtd_to_proto_duplicate_nested_enums(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -982,7 +996,7 @@ def test_jtd_to_proto_sad_labels(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -1003,7 +1017,7 @@ def test_jtd_to_proto_misaligned_keys(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -1028,7 +1042,7 @@ def test_nested_registration_conflict(temp_dpool):
         descriptor_pool=temp_dpool,
         validate_jtd=True,
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         jtd_to_proto(
             msg_name,
             package,
@@ -1039,6 +1053,87 @@ def test_nested_registration_conflict(temp_dpool):
             },
             descriptor_pool=temp_dpool,
             validate_jtd=True,
+        )
+
+
+def test_protoc_collision_different_file_names_with_import_compiled_first(temp_dpool):
+    """Test that we get a TypeError if we add a protoc compiled object -> do a sad JTD to proto."""
+    # This is what happens when you end up importing something compiled by recent
+    # versions of protoc; this was generated via protoc version 3.21.12.
+    protoc_sample = b'\n\x10sadmessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    temp_dpool.AddSerializedFile(protoc_sample)
+
+    # NOTE - Since the name of the message (OuterMessage) does not match the proto file name
+    # we compiled (sadmessage.proto), our direct validation is skipped, because we use that
+    # to look up the FileDescriptor. Since we can't find the FileDescriptor, we (currently)
+    # can't validate the message types it contains.
+    with pytest.raises(TypeError):
+        jtd_to_proto(
+            name="OuterMessage",
+            package="test.jtd_to_proto",
+            jtd_def={"properties": {"primitive": {"type": "string"}}},
+            validate_jtd=True,
+            descriptor_pool=temp_dpool,
+        )
+
+
+def test_protoc_collision_different_file_names_with_import_compiled_last(temp_dpool):
+    """Test that we get a TypeError if we do JTD to proto -> add a protoc compiled object."""
+    jtd_to_proto(
+        name="OuterMessage",
+        package="test.jtd_to_proto",
+        jtd_def={"properties": {"primitive": {"type": "string"}}},
+        validate_jtd=True,
+        descriptor_pool=temp_dpool,
+    )
+
+    # This is what happens when you end up importing something compiled by recent
+    # versions of protoc; this was generated via protoc version 3.21.12.
+    protoc_sample = b'\n\x10sadmessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    # Descriptor pool does not like this because it is a different file descriptor and the def
+    # of Message type OuterMessage changed; TypeError with duplicate symbols.
+    # NOTE - yes, this is a test for the descriptor pool API, but the reason is we test the
+    # opposite operation order above, and these error types should be consistent to make them
+    # easier for people to understand & handle.
+    with pytest.raises(TypeError):
+        temp_dpool.AddSerializedFile(protoc_sample)
+
+
+def test_protoc_collision_different_def_jtd_to_proto_first(temp_dpool):
+    """Test that we get a TypeError if we JTD to proto -> import serialized def that conflicts."""
+    jtd_to_proto(
+        name="OuterMessage",
+        package="test.jtd_to_proto",
+        jtd_def={"properties": {"foobar": {"type": "int32"}}},
+        validate_jtd=True,
+        descriptor_pool=temp_dpool,
+    )
+    # NOTE: This is essentially testing the behavior of protobufs descriptor pool when you have a
+    # conflict, but we do this explicitly here since we have a similar test for jtd to proto last;
+    # the behavior of these things should be the same, otherwise we may have different behavior
+    # based on import order.
+    #
+    # This is what happens when you end up importing something compiled by recent
+    # versions of protoc; this was generated via protoc version 3.21.12.
+    protoc_sample = b'\n\x12outermessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    with pytest.raises(TypeError):
+        temp_dpool.AddSerializedFile(protoc_sample)
+
+
+def test_protoc_collision_different_def_jtd_to_proto_last(temp_dpool):
+    """Test that we get a TypeError if we import serialized def -> JTD to proto that conflicts."""
+    # This is what happens when you end up importing something compiled by recent
+    # versions of protoc; this was generated via protoc version 3.21.12.
+    protoc_sample = b'\n\x12outermessage.proto\x12\x11test.jtd_to_proto"!\n\x0cOuterMessage\x12\x11\n\tprimitive\x18\x01 \x01(\tb\x06proto3'
+    temp_dpool.AddSerializedFile(protoc_sample)
+    # Now that it's in our descriptor pool, we are sad in future JTD to proto calls!
+    with pytest.raises(TypeError):
+        jtd_to_proto(
+            name="OuterMessage",
+            package="test.jtd_to_proto",
+            jtd_def={"properties": {"foobar": {"type": "int32"}}},
+            validate_jtd=True,
+            descriptor_pool=temp_dpool,
         )
 
 

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -746,7 +746,7 @@ def test_jtd_to_proto_duplicate_message(temp_dpool):
     assert descriptor is descriptor2
 
 
-def test_type_names_are_fully_qualified_with_nested_messages():
+def test_type_names_are_fully_qualified_with_nested_messages(temp_dpool):
     """Make sure that type_names are fully qualified with nested messages."""
     descriptor = jtd_to_proto(
         "First",
@@ -760,6 +760,7 @@ def test_type_names_are_fully_qualified_with_nested_messages():
                 },
             }
         },
+        descriptor_pool=temp_dpool,
     )
     # Copy our descriptor over to a proto & make sure it's type_name look correct
     dproto = descriptor_pb2.DescriptorProto()
@@ -774,10 +775,13 @@ def test_type_names_are_fully_qualified_with_nested_messages():
     assert dproto.nested_type[0].field[0].type_name == package_mapping["Third"]
 
 
-def test_type_names_are_fully_qualified_with_multiple_packages():
+def test_type_names_are_fully_qualified_with_multiple_packages(temp_dpool):
     """Make sure that type_names are fully qualified with multiple packages."""
     bar_descriptor = jtd_to_proto(
-        "Bar", "barpackage", {"properties": {"mydata": {"type": "string"}}}
+        "Bar",
+        "barpackage",
+        {"properties": {"mydata": {"type": "string"}}},
+        descriptor_pool=temp_dpool,
     )
     foo_descriptor = jtd_to_proto(
         "Foo",
@@ -787,6 +791,7 @@ def test_type_names_are_fully_qualified_with_multiple_packages():
                 "external_friend": {"type": bar_descriptor},
             }
         },
+        descriptor_pool=temp_dpool,
     )
     foo_dproto = descriptor_pb2.DescriptorProto()
     foo_descriptor.CopyToProto(foo_dproto)

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -10,11 +10,7 @@ import pytest
 
 # Local
 from jtd_to_proto.json_to_service import json_to_service
-from jtd_to_proto.jtd_to_proto import (
-    _have_same_type_name,
-    _to_upper_camel,
-    jtd_to_proto,
-)
+from jtd_to_proto.jtd_to_proto import _to_upper_camel, jtd_to_proto
 
 ## Happy Path ##################################################################
 
@@ -725,11 +721,11 @@ def test_jtd_to_proto_default_dpool():
 
 def test_jtd_to_proto_duplicate_message(temp_dpool):
     """Check that we can register the same message twice"""
-    msg_name = "Foo"
-    package = "foo.bar"
+    msg_name = "Message"
+    package = "package"
     schema = {
         "properties": {
-            "foo": {"properties": {"bar": {"type": "boolean"}}},
+            "fooz": {"properties": {"bar": {"type": "boolean"}}},
         }
     }
     descriptor = jtd_to_proto(
@@ -992,10 +988,3 @@ def test_nested_registration_conflict(temp_dpool):
 def test_to_upper_camel_empty():
     """Make sure _to_upper_camel is safe with an empty string"""
     assert _to_upper_camel("") == ""
-
-
-def test_to_type_name_validation():
-    """Make sure _to_upper_camel is safe with an empty string"""
-    assert _have_same_type_name("Foo", "Foo")
-    assert _have_same_type_name(".foo.bar.Foo", "Foo")
-    assert not _have_same_type_name("Bar", "Foo")

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -725,9 +725,7 @@ def test_jtd_to_proto_duplicate_message(temp_dpool):
     package = "foo.bar"
     schema = {
         "properties": {
-            "foo": {
-                "type": "boolean",
-            },
+            "foo": {"properties": {"bar": {"type": "boolean"}}},
         }
     }
     descriptor = jtd_to_proto(

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -935,6 +935,42 @@ def test_jtd_to_proto_duplicate_enum_name_different_length(temp_dpool):
         )
 
 
+def test_jtd_to_proto_duplicate_nested_enums(temp_dpool):
+    """Check that we cannot register a different message of the same name with sad nested enums"""
+    msg_name = "Foo"
+    package = "foo.bar"
+    # Conflicting values for a nested enum in a message that otherwise aligns
+    first_schema = {
+        "properties": {
+            "baz": {
+                "enum": ["Hello", "World"],
+            },
+        },
+    }
+    second_schema = {
+        "properties": {
+            "baz": {
+                "enum": ["Hello", "World", "And an extra value that we don't expect!"],
+            },
+        },
+    }
+    jtd_to_proto(
+        msg_name,
+        package,
+        first_schema,
+        descriptor_pool=temp_dpool,
+        validate_jtd=True,
+    )
+    with pytest.raises(ValueError):
+        jtd_to_proto(
+            msg_name,
+            package,
+            second_schema,
+            descriptor_pool=temp_dpool,
+            validate_jtd=True,
+        )
+
+
 def test_jtd_to_proto_sad_labels(temp_dpool):
     """Check that we cannot register a different message with field properties, e.g., label."""
     msg_name = "Foo"

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -911,6 +911,30 @@ def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
         )
 
 
+def test_jtd_to_proto_duplicate_enum_name(temp_dpool):
+    """Check that we cannot register a different message with the same name with wrong enum vals"""
+    msg_name = "Foo"
+    package = "foo.bar"
+    # The respective values we are going to register
+    first_enum_values = ["Hello", "World"]
+    second_enum_values = ["Hello", "World", "And an extra value that we don't expect!"]
+    jtd_to_proto(
+        msg_name,
+        package,
+        {"enum": first_enum_values},
+        descriptor_pool=temp_dpool,
+        validate_jtd=True,
+    )
+    with pytest.raises(ValueError):
+        jtd_to_proto(
+            msg_name,
+            package,
+            {"enum": second_enum_values},
+            descriptor_pool=temp_dpool,
+            validate_jtd=True,
+        )
+
+
 def test_jtd_to_proto_sad_labels(temp_dpool):
     """Check that we cannot register a different message with field properties, e.g., label."""
     msg_name = "Foo"


### PR DESCRIPTION
There are some problems in the way that we check our messages when registering things into the descriptor pool. This PR addresses them by building and comparing `FileDescriptorProto` objects for the potential conflict. More details provided in summary of changes!


### Sample Repro Case
The serialized content for the same proto objects is not always consistent. Depending on how things are created & where they are validated things like `type_name` may not be fully qualified, and for some (mysterious) reason, there are false collision errors when nested types are used.

A simple repro case for the latter is outlined below:

Happy - no nested messages
```python3
from jtd_to_proto import jtd_to_proto

msg_name = "Foo"
package = "foo.bar"
schema = {"properties": {"foo": {"type": "boolean"}}}
jtd_to_proto(msg_name,package, schema)
# Registration with the descriptor pool is idempotent, which is expected
jtd_to_proto(msg_name,package, schema)
```

Not happy; raises `ValueError: Cannot add new file foo.proto to descriptor pool, file already exists with different content`
```python3
from jtd_to_proto import jtd_to_proto

msg_name = "Foo"
package = "foo.bar"
schema = {"properties": {"foo": {"properties": {"bar": {"type": "boolean"}}}}}
jtd_to_proto(msg_name,package, schema)
# Breaks unexpectedly
jtd_to_proto(msg_name,package, schema)
```
Note that this case is handled in `test_jtd_to_proto_duplicate_message`. 

### Summary of Changes
Two FileDescriptors are considered equal if their protos satisfy the following:
- They have the same package
- They have the same dependency
- All of their enums are well-aligned, i.e., they have the same `enum_type` names, and for any/all of those, every enum val/number lines up correctly
- All of their messages are well-aligned, i.e., they have the same `message_type` names, and for each message, every field has the same `label`, `type`, and `type_name`. For the last one, we provide some flexibility in case we're comparing something that isn't fully qualified to something that is