### PR TITLE
Add .to_proto_file support for Services

### DIFF
--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -34,6 +34,10 @@ PROTO_FILE_MESSAGE_HEADER = """
 /*-- MESSAGES ----------------------------------------------------------------*/
 """
 
+PROTO_FILE_SERVICES_HEADER = """
+/*-- SERVICES ----------------------------------------------------------------*/
+"""
+
 PROTO_FILE_NESTED_ENUM_HEADER = f"{PROTO_FILE_INDENT}/*-- nested enums --*/"
 PROTO_FILE_NESTED_MESSAGE_HEADER = f"{PROTO_FILE_INDENT}/*-- nested messages --*/"
 PROTO_FILE_FIELD_HEADER = f"{PROTO_FILE_INDENT}/*-- fields --*/"
@@ -44,7 +48,7 @@ PROTO_FILE_ONEOF_HEADER = f"{PROTO_FILE_INDENT}/*-- oneofs --*/"
 
 
 def descriptor_to_file(
-    descriptor: Union[_descriptor.FileDescriptor, _descriptor.Descriptor],
+    descriptor: Union[_descriptor.FileDescriptor, _descriptor.Descriptor, _descriptor.ServiceDescriptor],
 ) -> str:
     """Serialize a .proto file from a FileDescriptor
 
@@ -58,7 +62,7 @@ def descriptor_to_file(
     """
 
     # If this is a message descriptor, use its corresponding FileDescriptor
-    if isinstance(descriptor, (_descriptor.Descriptor, _descriptor.EnumDescriptor)):
+    if isinstance(descriptor, (_descriptor.Descriptor, _descriptor.EnumDescriptor, _descriptor.ServiceDescriptor)):
         descriptor = descriptor.file
     if not isinstance(descriptor, _descriptor.FileDescriptor):
         raise ValueError(f"Invalid file descriptor of type {type(descriptor)}")
@@ -88,6 +92,13 @@ def descriptor_to_file(
         for message_descriptor in descriptor.message_types_by_name.values():
             proto_file_lines.extend(_message_descriptor_to_file(message_descriptor))
             proto_file_lines.append("")
+
+    if descriptor.services_by_name:
+        proto_file_lines.append(PROTO_FILE_SERVICES_HEADER)
+        for service_descriptor in descriptor.services_by_name.values():
+            proto_file_lines.extend(_service_descriptor_to_file(service_descriptor))
+            proto_file_lines.append("")
+
 
     return "\n".join(proto_file_lines)
 
@@ -162,6 +173,17 @@ def _message_descriptor_to_file(
     lines.append("}")
     return _indent_lines(indent, lines)
 
+def _service_descriptor_to_file(
+    service_descriptor: _descriptor.ServiceDescriptor,
+    indent: int = 0,
+) -> List[str]:
+    """Make the string representation of a service"""
+    lines = []
+    lines.append(f"service {service_descriptor.name} {{")
+    for method in service_descriptor.methods:
+        lines.append(f"{PROTO_FILE_INDENT}rpc {method.name}({method.input_type}) returns ({method.output_type});")
+    lines.append("}")
+    return _indent_lines(indent, lines)
 
 def _field_descriptor_to_file(
     field_descriptor: _descriptor.FieldDescriptor,

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -48,7 +48,11 @@ PROTO_FILE_ONEOF_HEADER = f"{PROTO_FILE_INDENT}/*-- oneofs --*/"
 
 
 def descriptor_to_file(
-    descriptor: Union[_descriptor.FileDescriptor, _descriptor.Descriptor, _descriptor.ServiceDescriptor],
+    descriptor: Union[
+        _descriptor.FileDescriptor,
+        _descriptor.Descriptor,
+        _descriptor.ServiceDescriptor,
+    ],
 ) -> str:
     """Serialize a .proto file from a FileDescriptor
 
@@ -62,7 +66,14 @@ def descriptor_to_file(
     """
 
     # If this is a message descriptor, use its corresponding FileDescriptor
-    if isinstance(descriptor, (_descriptor.Descriptor, _descriptor.EnumDescriptor, _descriptor.ServiceDescriptor)):
+    if isinstance(
+        descriptor,
+        (
+            _descriptor.Descriptor,
+            _descriptor.EnumDescriptor,
+            _descriptor.ServiceDescriptor,
+        ),
+    ):
         descriptor = descriptor.file
     if not isinstance(descriptor, _descriptor.FileDescriptor):
         raise ValueError(f"Invalid file descriptor of type {type(descriptor)}")
@@ -98,7 +109,6 @@ def descriptor_to_file(
         for service_descriptor in descriptor.services_by_name.values():
             proto_file_lines.extend(_service_descriptor_to_file(service_descriptor))
             proto_file_lines.append("")
-
 
     return "\n".join(proto_file_lines)
 
@@ -173,6 +183,7 @@ def _message_descriptor_to_file(
     lines.append("}")
     return _indent_lines(indent, lines)
 
+
 def _service_descriptor_to_file(
     service_descriptor: _descriptor.ServiceDescriptor,
     indent: int = 0,
@@ -181,9 +192,12 @@ def _service_descriptor_to_file(
     lines = []
     lines.append(f"service {service_descriptor.name} {{")
     for method in service_descriptor.methods:
-        lines.append(f"{PROTO_FILE_INDENT}rpc {method.name}({method.input_type.full_name}) returns ({method.output_type.full_name});")
+        lines.append(
+            f"{PROTO_FILE_INDENT}rpc {method.name}({method.input_type.full_name}) returns ({method.output_type.full_name});"
+        )
     lines.append("}")
     return _indent_lines(indent, lines)
+
 
 def _field_descriptor_to_file(
     field_descriptor: _descriptor.FieldDescriptor,

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -181,7 +181,7 @@ def _service_descriptor_to_file(
     lines = []
     lines.append(f"service {service_descriptor.name} {{")
     for method in service_descriptor.methods:
-        lines.append(f"{PROTO_FILE_INDENT}rpc {method.name}({method.input_type}) returns ({method.output_type});")
+        lines.append(f"{PROTO_FILE_INDENT}rpc {method.name}({method.input_type.full_name}) returns ({method.output_type.full_name});")
     lines.append("}")
     return _indent_lines(indent, lines)
 

--- a/jtd_to_proto/descriptor_to_message_class.py
+++ b/jtd_to_proto/descriptor_to_message_class.py
@@ -60,7 +60,7 @@ def descriptor_to_message_class(
                 descriptor_to_message_class(nested_enum_descriptor),
             )
 
-    message_class = _add_to_proto_write_proto(message_class, descriptor)
+    message_class = _add_protobuf_serializers(message_class, descriptor)
     return message_class
 
 
@@ -90,7 +90,7 @@ def _maybe_classmethod(func: Callable, parent: Any):
     setattr(parent, func.__name__, _wrapper)
 
 
-def _add_to_proto_write_proto(
+def _add_protobuf_serializers(
         type_class: Union[Type[_message.Message], EnumTypeWrapper, Type[service.Service]],
         descriptor: Union[_descriptor.Descriptor, _descriptor.EnumDescriptor, _descriptor.ServiceDescriptor],
 ) -> Union[Type[_message.Message], EnumTypeWrapper, Type[service.Service]]:

--- a/jtd_to_proto/descriptor_to_message_class.py
+++ b/jtd_to_proto/descriptor_to_message_class.py
@@ -13,17 +13,16 @@ import os
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection, service
-from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 from google.protobuf.descriptor import ServiceDescriptor
+from google.protobuf.internal.enum_type_wrapper import EnumTypeWrapper
 from google.protobuf.service import Service
-
 
 # Local
 from .descriptor_to_file import descriptor_to_file
 
 
 def descriptor_to_message_class(
-        descriptor: Union[_descriptor.Descriptor, _descriptor.EnumDescriptor],
+    descriptor: Union[_descriptor.Descriptor, _descriptor.EnumDescriptor],
 ) -> Union[Type[_message.Message], EnumTypeWrapper]:
     """Create the proto class from the given descriptor
 
@@ -91,8 +90,12 @@ def _maybe_classmethod(func: Callable, parent: Any):
 
 
 def _add_protobuf_serializers(
-        type_class: Union[Type[_message.Message], EnumTypeWrapper, Type[service.Service]],
-        descriptor: Union[_descriptor.Descriptor, _descriptor.EnumDescriptor, _descriptor.ServiceDescriptor],
+    type_class: Union[Type[_message.Message], EnumTypeWrapper, Type[service.Service]],
+    descriptor: Union[
+        _descriptor.Descriptor,
+        _descriptor.EnumDescriptor,
+        _descriptor.ServiceDescriptor,
+    ],
 ) -> Union[Type[_message.Message], EnumTypeWrapper, Type[service.Service]]:
     """Helper to add the to_proto_file and write_proto_file to a given type class.
 
@@ -107,6 +110,7 @@ def _add_protobuf_serializers(
     """
     # Add to_proto_file
     if not hasattr(type_class, "to_proto_file"):
+
         def to_proto_file(first_arg) -> str:
             f"Create the serialized .proto file content holding all definitions for {descriptor.name}"
             return descriptor_to_file(first_arg.DESCRIPTOR)
@@ -115,10 +119,11 @@ def _add_protobuf_serializers(
 
     # Add write_proto_file
     if not hasattr(type_class, "write_proto_file"):
+
         def write_proto_file(first_arg, root_dir: str = "."):
             "Write out the proto file to the target directory"
             with open(
-                    os.path.join(root_dir, first_arg.DESCRIPTOR.file.name), "w"
+                os.path.join(root_dir, first_arg.DESCRIPTOR.file.name), "w"
             ) as handle:
                 handle.write(first_arg.to_proto_file())
 

--- a/jtd_to_proto/json_to_service.py
+++ b/jtd_to_proto/json_to_service.py
@@ -19,7 +19,7 @@ import alog
 
 # Local
 from jtd_to_proto import descriptor_to_message_class
-from jtd_to_proto.descriptor_to_message_class import _add_to_proto_write_proto
+from jtd_to_proto.descriptor_to_message_class import _add_protobuf_serializers
 
 log = alog.use_channel("JSON2S")
 
@@ -156,7 +156,7 @@ def service_descriptor_to_service(
         {"metaclass": GeneratedServiceType},
         lambda ns: ns.update({"DESCRIPTOR": service_descriptor}),
     )
-    service_class = _add_to_proto_write_proto(service_class, service_descriptor)
+    service_class = _add_protobuf_serializers(service_class, service_descriptor)
 
     return service_class
 

--- a/jtd_to_proto/json_to_service.py
+++ b/jtd_to_proto/json_to_service.py
@@ -48,11 +48,11 @@ ServiceJsonType = Dict[str, Dict[str, List[Dict[str, str]]]]
 
 
 def json_to_service(
-        name: str,
-        package: str,
-        json_service_def: ServiceJsonType,
-        *,
-        descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
+    name: str,
+    package: str,
+    json_service_def: ServiceJsonType,
+    *,
+    descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
 ) -> _descriptor.ServiceDescriptor:
     """Convert a JSON representation of an RPC service into a ServiceDescriptor.
 
@@ -137,7 +137,7 @@ def json_to_service(
 
 
 def service_descriptor_to_service(
-        service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: _descriptor.ServiceDescriptor,
 ) -> Type[service.Service]:
     """Create a service class from a service descriptor
 
@@ -162,7 +162,7 @@ def service_descriptor_to_service(
 
 
 def service_descriptor_to_client_stub(
-        service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: _descriptor.ServiceDescriptor,
 ) -> Type:
     """Generates a new client stub class from the service descriptor
 
@@ -197,7 +197,7 @@ def service_descriptor_to_client_stub(
 
 
 def service_descriptor_to_server_registration_function(
-        service_descriptor: _descriptor.ServiceDescriptor,
+    service_descriptor: _descriptor.ServiceDescriptor,
 ) -> Callable[[Service, grpc.Server], None]:
     """Generates a server registration function from the service descriptor
 

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -197,8 +197,6 @@ JTD_TO_PROTO_TYPES = {
     "uint8": _descriptor.FieldDescriptor.TYPE_UINT32,
     "int16": _descriptor.FieldDescriptor.TYPE_INT32,
     "uint16": _descriptor.FieldDescriptor.TYPE_UINT32,
-    "int8": _descriptor.FieldDescriptor.TYPE_INT32,
-    "uint8": _descriptor.FieldDescriptor.TYPE_UINT32,
     "int32": _descriptor.FieldDescriptor.TYPE_INT32,
     "uint32": _descriptor.FieldDescriptor.TYPE_UINT32,
     "int64": _descriptor.FieldDescriptor.TYPE_INT64,

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -4,7 +4,7 @@ Tests for descriptor_to_file
 
 # Standard
 from types import ModuleType
-from typing import Optional, List, Dict
+from typing import Dict, List, Optional
 import importlib
 import os
 import random
@@ -21,9 +21,9 @@ import pytest
 import alog
 
 # Local
-from jtd_to_proto.json_to_service import json_to_service
 from .conftest import temp_dpool
 from jtd_to_proto.descriptor_to_file import descriptor_to_file
+from jtd_to_proto.json_to_service import json_to_service
 from jtd_to_proto.jtd_to_proto import jtd_to_proto
 
 log = alog.use_channel("TEST")
@@ -122,14 +122,14 @@ sample_jtd_def = jtd_def = {
 }
 
 
-def compile_proto_module(proto_content: str, imported_file_contents: Dict[str, str] = None) -> Optional[ModuleType]:
+def compile_proto_module(
+    proto_content: str, imported_file_contents: Dict[str, str] = None
+) -> Optional[ModuleType]:
     """Compile the proto file content locally"""
     with tempfile.TemporaryDirectory() as dirname:
         mod_name = "{}_temp".format(
             "".join([random.choice(string.ascii_lowercase) for _ in range(8)])
         )
-
-        print("MODE NAME:", mod_name)
 
         fname = os.path.join(dirname, f"{mod_name}.proto")
         with open(fname, "w") as handle:
@@ -159,8 +159,6 @@ def compile_proto_module(proto_content: str, imported_file_contents: Dict[str, s
 
         # Put this dir on the sys.path and load the module
         sys.path.append(dirname)
-
-        print("Files in tempdir:", os.listdir(dirname))
 
         mod = importlib.import_module(f"{mod_name}_pb2")
         sys.path.pop()
@@ -274,16 +272,19 @@ def test_descriptor_to_file_service_descriptor(temp_dpool):
                 ]
             }
         },
-        descriptor_pool=temp_dpool
+        descriptor_pool=temp_dpool,
     )
     # TODO: type annotation fixup
     res = descriptor_to_file(service_descriptor)
     assert "service FooService {" in res
 
+
 def test_descriptor_to_file_compilable_proto_with_service_descriptor(temp_dpool):
     """Make sure descriptor_to_file can be called on a ServiceDescriptor"""
 
-    random_message_name = "".join([random.choice(string.ascii_lowercase) for _ in range(8)])
+    random_message_name = "".join(
+        [random.choice(string.ascii_lowercase) for _ in range(8)]
+    )
     # 🌶️🌶️🌶️ The message names must be capitalized to work
     random_message_name = random_message_name.capitalize()
 
@@ -299,9 +300,7 @@ def test_descriptor_to_file_compilable_proto_with_service_descriptor(temp_dpool)
         descriptor_pool=temp_dpool,
     )
     message_descriptor_file = descriptor_to_file(foo_message_descriptor)
-    imported_files = {
-        foo_message_descriptor.file.name: message_descriptor_file
-    }
+    imported_files = {foo_message_descriptor.file.name: message_descriptor_file}
     service_descriptor = json_to_service(
         name=f"{random_message_name}Service",
         package="foo.bar",
@@ -316,8 +315,7 @@ def test_descriptor_to_file_compilable_proto_with_service_descriptor(temp_dpool)
                 ]
             }
         },
-        descriptor_pool=temp_dpool
+        descriptor_pool=temp_dpool,
     )
     res = descriptor_to_file(service_descriptor)
-    print(res)
     assert compile_proto_module(res, imported_file_contents=imported_files)

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -21,6 +21,7 @@ import pytest
 import alog
 
 # Local
+from jtd_to_proto.json_to_service import json_to_service
 from .conftest import temp_dpool
 from jtd_to_proto.descriptor_to_file import descriptor_to_file
 from jtd_to_proto.jtd_to_proto import jtd_to_proto
@@ -229,3 +230,37 @@ def test_descriptor_to_file_enum_descriptor(temp_dpool):
     )
     res = descriptor_to_file(enum_descriptor)
     assert "enum Foo {" in res
+
+
+def test_descriptor_to_file_service_descriptor(temp_dpool):
+    """Make sure descriptor_to_file can be called on a ServiceDescriptor"""
+    foo_message_descriptor = jtd_to_proto(
+        "Foo",
+        "foo.bar",
+        {
+            "properties": {
+                "foo": {"type": "boolean"},
+                "bar": {"type": "float32"},
+            }
+        },
+        descriptor_pool=temp_dpool,
+    )
+    service_descriptor = json_to_service(
+        name="FooService",
+        package="foo.bar",
+        json_service_def={
+            "service": {
+                "rpcs": [
+                    {
+                        "name": "FooPredict",
+                        "input_type": "foo.bar.Foo",
+                        "output_type": "foo.bar.Foo",
+                    }
+                ]
+            }
+        },
+        descriptor_pool=temp_dpool
+    )
+    # TODO: type annotation fixup
+    res = descriptor_to_file(service_descriptor)
+    assert "service FooService {" in res

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -3,6 +3,7 @@ Tests for json_to_service functions
 """
 
 # Standard
+import os
 from concurrent import futures
 import types
 
@@ -147,6 +148,20 @@ def test_service_descriptor_to_service(foo_service_descriptor):
 
     assert hasattr(ServiceClass, "FooPredict")
     assert ServiceClass.__name__ == foo_service_descriptor.name
+
+
+def test_services_can_be_written_to_protobuf_files(foo_service_descriptor, tmp_path):
+    """Ensure that service class can be created from service descriptor"""
+    ServiceClass = service_descriptor_to_service(foo_service_descriptor)
+
+    assert hasattr(ServiceClass, "to_proto_file")
+    assert hasattr(ServiceClass, "write_proto_file")
+
+    tempdir = str(tmp_path)
+    ServiceClass.write_proto(tempdir)
+    assert "foo_service.proto" in os.listdir(tempdir)
+    with open(os.path.join(tempdir, "foo_service.proto"), "r") as f:
+        assert "service FooService {" in f.read()
 
 
 def test_service_descriptor_to_client_stub(foo_service_descriptor):

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -158,9 +158,9 @@ def test_services_can_be_written_to_protobuf_files(foo_service_descriptor, tmp_p
     assert hasattr(ServiceClass, "write_proto_file")
 
     tempdir = str(tmp_path)
-    ServiceClass.write_proto(tempdir)
-    assert "foo_service.proto" in os.listdir(tempdir)
-    with open(os.path.join(tempdir, "foo_service.proto"), "r") as f:
+    ServiceClass.write_proto_file(tempdir)
+    assert "fooservice.proto" in os.listdir(tempdir)
+    with open(os.path.join(tempdir, "fooservice.proto"), "r") as f:
         assert "service FooService {" in f.read()
 
 

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -3,8 +3,8 @@ Tests for json_to_service functions
 """
 
 # Standard
-import os
 from concurrent import futures
+import os
 import types
 
 # Third Party


### PR DESCRIPTION
Changes in PR address [Add .to_proto_file support for Services](https://github.com/IBM/jtd-to-proto/issues/30):

- extends `descriptor_to_file` to include ServiceDescriptor support
- updates to `service_descriptor_to_service` to enable write_proto and to_proto
- new method `_add_protobuf_serializers` to reduce redundancy

Concerns:
- we're importing a private method `_add_protobuf_serializers` to `json_to_service.py` and want to consider whether this should be a public method instead.