### PR TITLE
Optional jtd dependency

### DIFF
--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -9,7 +9,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import struct_pb2, timestamp_pb2
-import jtd
 
 # First Party
 import alog
@@ -244,7 +243,16 @@ def jtd_to_proto(
     # the results
     if validate_jtd:
         log.debug2("Validating JTD")
-        jtd.schema.Schema.from_dict(jtd_def)
+        try:
+            # Third Party
+            import jtd
+
+            jtd.schema.Schema.from_dict(jtd_def)
+        except ImportError:
+            log.warning(
+                "Validation missing dependencies. To enable, pip install jtd_to_proto[validation]"
+            )
+            log.warning("WARNING: This includes GPLv3 licensed dependencies")
 
     # This list will be used to aggregate the list of message DescriptorProtos
     # for any nested message objects defined inline

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 protobuf>=3.20.*,<5
-jtd==0.1.*
 alchemy-logging>=1.0.3
+
+# Optional with [validation]
+jtd==0.1.*

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,13 @@ assert version is not None, "Must set RELEASE_VERSION"
 
 # Read in the requirements
 with open(os.path.join(python_base, "requirements.txt"), "r") as handle:
-    requirements = handle.read()
+    requirements = handle.read().split("\n")
+
+
+# Split out jtd as the optional requirement for validation
+jtd_req = [req for req in requirements if req.startswith("jtd")]
+requirements = list(set(requirements) - set(jtd_req))
+extras_require = {"validation": jtd_req}
 
 setup(
     name="jtd_to_proto",
@@ -40,4 +46,5 @@ setup(
     keywords=["json", "json typedef", "jtd", "protobuf", "proto"],
     packages=["jtd_to_proto"],
     install_requires=requirements,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
## Description

This PR makes `jtd` an optional dependency that is not required to use the majority of the library functionality, but can be installed using `pip install jtd_to_proto[validation]`