### PR TITLE
Internal validation

### DIFF
--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -9,10 +9,12 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import struct_pb2, timestamp_pb2
-import jtd
 
 # First Party
 import alog
+
+# Local
+from .validation import is_valid_jtd
 
 log = alog.use_channel("JTD2P")
 
@@ -215,6 +217,7 @@ def jtd_to_proto(
     jtd_def: Dict[str, Union[dict, str]],
     *,
     validate_jtd: bool = False,
+    valid_types: Optional[List[str]] = None,
     descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
 ) -> _descriptor.Descriptor:
     """Convert a JTD schema into a set of proto DESCRIPTOR objects.
@@ -244,7 +247,9 @@ def jtd_to_proto(
     # the results
     if validate_jtd:
         log.debug2("Validating JTD")
-        jtd.schema.Schema.from_dict(jtd_def)
+        valid_types = valid_types or JTD_TO_PROTO_TYPES.keys()
+        if not is_valid_jtd(jtd_def, valid_types=valid_types):
+            raise ValueError(f"Invalid JTD Schema: {jtd_def}")
 
     # This list will be used to aggregate the list of message DescriptorProtos
     # for any nested message objects defined inline

--- a/jtd_to_proto/validation.py
+++ b/jtd_to_proto/validation.py
@@ -4,27 +4,31 @@ This module implements recursive JTD schema validation
 https://www.rfc-editor.org/rfc/rfc8927
 """
 # Standard
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
 
 # First Party
 import alog
 
 log = alog.use_channel("JTD2P")
 
+# Map of type validators for standard JTD types
+JTD_TYPE_VALIDATORS = {
+    "boolean": lambda x: isinstance(x, bool),
+    "float32": lambda x: isinstance(x, (int, float)),
+    "float64": lambda x: isinstance(x, (int, float)),
+    "int8": lambda x: isinstance(x, int),
+    "uint8": lambda x: isinstance(x, int) and x >= 0,
+    "int16": lambda x: isinstance(x, int),
+    "uint16": lambda x: isinstance(x, int) and x >= 0,
+    "int32": lambda x: isinstance(x, int),
+    "uint32": lambda x: isinstance(x, int) and x >= 0,
+    "string": lambda x: isinstance(x, str),
+    "timestamp": lambda x: isinstance(x, datetime),
+}
+
 # List of standard type names
-JTD_TYPES = [
-    "boolean",
-    "float32",
-    "float64",
-    "int8",
-    "uint8",
-    "int16",
-    "uint16",
-    "int32",
-    "uint32",
-    "string",
-    "timestamp",
-]
+JTD_TYPES = list(JTD_TYPE_VALIDATORS.keys())
 
 
 def is_valid_jtd(
@@ -47,9 +51,38 @@ def is_valid_jtd(
     return _is_valid_jtd_impl(schema, valid_types, is_root_schema=True)
 
 
+def validate_jtd(
+    obj: Any,
+    schema: Dict[str, Any],
+    type_validators: Optional[Dict[str, Callable[[Any], bool]]] = None,
+) -> bool:
+    """Validate the given object against the given schema
+
+    Args:
+        obj (Any)
+            The candidate object to validate
+        schema (Dict[str, Any])
+            The schema to validate against
+        type_validators (Optional[Dict[str, Callable[[Any], bool]]])
+            Mapping from types string names to validation functions
+
+    Returns:
+        is_valid (bool)
+            True if the object matches the schema, False otherwise
+    """
+    type_validators = type_validators or JTD_TYPE_VALIDATORS
+    if not is_valid_jtd(schema, type_validators.keys()):
+        raise ValueError(f"Invalid schema: {schema}")
+    return _validate_jtd_impl(obj, schema, type_validators, is_root_schema=True)
+
+
 ## Implementation ##############################################################
 
 _SHARED_KEYS = {"nullable", "metadata", "definitions"}
+
+
+def _is_string_key_dict(value: Any) -> bool:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
 
 
 def _is_valid_jtd_impl(
@@ -195,6 +228,11 @@ def _is_valid_jtd_impl(
                 not _is_valid_jtd_impl(val, valid_types, definitions)
                 for val in mapping_val.values()
             )
+            # Mapping entries are of the "properties" form
+            or any(
+                "properties" not in val and "optionalProperties" not in val
+                for val in mapping_val.values()
+            )
             # Mapping entry "nullable" matches discriminator "nullable"
             or any(
                 val.get("nullable", False) != nullable for val in mapping_val.values()
@@ -225,5 +263,148 @@ def _is_valid_jtd_impl(
     return False
 
 
-def _is_string_key_dict(value: Any) -> bool:
-    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+def _validate_jtd_impl(
+    obj: Any,
+    schema: Dict[str, Any],
+    type_validators: Dict[str, Callable[[Any], bool]],
+    definitions: Optional[Dict[str, Any]] = None,
+    *,
+    is_root_schema: bool = False,
+):
+    """Recursive validation implementation"""
+
+    # Pull out common definitions from the root that will be passed along
+    # everywhere
+    definitions = definitions or {}
+    if is_root_schema:
+        definitions = schema.get("definitions", {})
+
+    # Check to see if this schema is null and nullable
+    if obj is None and schema.get("nullable", False):
+        return True
+
+    # Get the set of keys in this schema with universal keys removed
+    schema_keys = set(schema.keys()) - _SHARED_KEYS
+
+    # Empty (3.3.1)
+    if not schema_keys:
+        return True
+
+    # Ref (3.3.2)
+    if schema_keys == {"ref"}:
+        ref_val = schema["ref"]
+        if not _validate_jtd_impl(
+            obj, definitions[ref_val], type_validators, definitions
+        ):
+            log.debug4("Invalid value <%s> or ref <%s>", obj, ref_val)
+            return False
+        return True
+
+    # Type (3.3.3)
+    if schema_keys == {"type"}:
+        type_val = schema["type"]
+        validator = type_validators.get(type_val)
+        if not (validator is not None and validator(obj)):
+            log.debug4("Invalid value <%s> for type <%s>", obj, type_val)
+            return False
+        return True
+
+    # Enum (3.3.4)
+    if schema_keys == {"enum"}:
+        enum_vals = schema["enum"]
+        if obj not in enum_vals:
+            log.debug4("Invalid enum value <%s> for enum <%s>", obj, enum_vals)
+            return False
+        return True
+
+    # Elements (3.3.5)
+    if schema_keys == {"elements"}:
+        element_schema = schema["elements"]
+        if not isinstance(obj, list) or any(
+            not _validate_jtd_impl(entry, element_schema, type_validators, definitions)
+            for entry in obj
+        ):
+            log.debug4(
+                "Invalid elements value <%s> for element schema <%s>",
+                obj,
+                element_schema,
+            )
+            return False
+        return True
+
+    # Properties (3.3.6)
+    if "properties" in schema_keys or "optionalProperties" in schema_keys:
+        if not _is_string_key_dict(obj):
+            log.debug4("Invalid properties <%s> is not a string key dict", obj)
+            return False
+        schema_properties = schema.get("properties", {})
+        schema_opt_properties = schema.get("optionalProperties", {})
+        if any(
+            prop not in obj
+            or not _validate_jtd_impl(
+                obj[prop],
+                prop_schema,
+                type_validators,
+                definitions,
+            )
+            for prop, prop_schema in schema_properties.items()
+        ):
+            log.debug4(
+                "Invalid properties <%s> for properties %s", obj, schema_properties
+            )
+            return False
+        if any(
+            prop in obj
+            and not _validate_jtd_impl(
+                obj[prop], prop_schema, type_validators, definitions
+            )
+            for prop, prop_schema in schema_opt_properties.items()
+        ):
+            log.debug4(
+                "Invalid optional properties <%s> for optional properties %s",
+                obj,
+                schema_opt_properties,
+            )
+            return False
+        all_props = set.union(
+            set(schema_properties.keys()), schema_opt_properties.keys()
+        )
+        if (
+            not schema.get("additionalProperties", False)
+            and set(obj.keys()) - all_props - _SHARED_KEYS
+        ):
+            log.debug4("Invalid additional properties in <%s> for %s", obj, schema)
+            return False
+        return True
+
+    # Values (3.3.7)
+    if schema_keys == {"values"}:
+        value_schema = schema["values"]
+        if not _is_string_key_dict(obj) or any(
+            not _validate_jtd_impl(entry, value_schema, type_validators, definitions)
+            for entry in obj.values()
+        ):
+            log.debug4("Invalid values <%s> for values schema <%s>", obj, value_schema)
+            return False
+        return True
+
+    # Discriminator (3.3.8)
+    if schema_keys == {"discriminator", "mapping"}:
+        if not _is_string_key_dict(obj):
+            log.debug4("Invalid discriminator <%s> which is not a string key dict", obj)
+            return False
+        schema_discriminator = schema["discriminator"]
+        schema_mapping = schema["mapping"]
+        discriminator_val = obj.get(schema_discriminator)
+        if discriminator_val not in schema_mapping or not _validate_jtd_impl(
+            {key: val for key, val in obj.items() if key != schema_discriminator},
+            schema_mapping[discriminator_val],
+            type_validators,
+            definitions,
+        ):
+            log.debug4("Invalid discriminator <%s> for schema %s", obj, schema)
+            return False
+        return True
+
+    # Since the schema must be valid, we should never get here!
+    raise ValueError(f"Programming Error: unhandled schema {schema}")

--- a/jtd_to_proto/validation.py
+++ b/jtd_to_proto/validation.py
@@ -1,0 +1,229 @@
+"""
+This module implements recursive JTD schema validation
+
+https://www.rfc-editor.org/rfc/rfc8927
+"""
+# Standard
+from typing import Any, Dict, List, Optional
+
+# First Party
+import alog
+
+log = alog.use_channel("JTD2P")
+
+# List of standard type names
+JTD_TYPES = [
+    "boolean",
+    "float32",
+    "float64",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "string",
+    "timestamp",
+]
+
+
+def is_valid_jtd(
+    schema: Dict[str, Any], valid_types: Optional[List[str]] = None
+) -> bool:
+    """Determine whether the given dict represents a valid JTD schema
+
+    Args:
+        schema (Dict[str, Any])
+            The candidate schema for validation
+        valid_types (Optional[List[str]])
+            List of valid type name strings. This defaults to the standard JTD
+            types, but can be changed/extended to support additional types
+
+    Returns:
+        is_valid (bool)
+            True if the schema is valid, False otherwise
+    """
+    valid_types = valid_types or JTD_TYPES
+    return _is_valid_jtd_impl(schema, valid_types, is_root_schema=True)
+
+
+## Implementation ##############################################################
+
+_SHARED_KEYS = {"nullable", "metadata", "definitions"}
+
+
+def _is_valid_jtd_impl(
+    schema: Dict[str, Any],
+    valid_types: List[str],
+    definitions: Optional[Dict[str, Any]] = None,
+    *,
+    is_root_schema: bool = False,
+) -> bool:
+    """Recursive implementation of schema validation"""
+
+    # Make sure it is a dict with string keys
+    if not _is_string_key_dict(schema):
+        log.debug4("Invalid jtd: Not a dict with string keys")
+        return False
+
+    # Check for metadata and/or nullable keywords which any form can contain
+    if not isinstance(schema.get("nullable", False), bool):
+        log.debug4("Invalid jtd: Found non-bool 'nullable'")
+        return False
+    if not _is_string_key_dict(schema.get("metadata", {})):
+        log.debug4("Invalid jtd: Found 'metadata' that is not a dict of strings")
+        return False
+
+    # Definitions (2.1)
+    definitions = definitions or {}
+    if is_root_schema:
+        definitions = schema.get("definitions", {})
+        if not _is_string_key_dict(definitions):
+            log.debug4("Invalid jtd: Found 'definitions' that is not a dict of strings")
+            return False
+        # TODO: Can definitions refer to _other_ definitions? The RFC is
+        #   ambiguous here, so I think it should _technically_ be possible, but
+        #   for our sake, we won't allow it for now.
+        if any(
+            not _is_valid_jtd_impl(val, valid_types) for val in definitions.values()
+        ):
+            log.debug4("Invalid jtd: Found 'definitions' value that is not valid jtd")
+            return False
+    elif "definitions" in schema:
+        log.debug4("Found 'definitions' in non-root schema")
+        return False
+
+    # Get the set of keys in this schema with universal keys removed
+    schema_keys = set(schema.keys()) - _SHARED_KEYS
+
+    # Empty (2.2.1)
+    if schema_keys == set():
+        return True
+
+    # Ref (2.2.2)
+    if schema_keys == {"ref"}:
+        ref_val = schema["ref"]
+        if not isinstance(ref_val, str) or ref_val not in definitions:
+            log.debug4("Invalid jtd: Bad reference <%s>", ref_val)
+            return False
+        return True
+
+    # Type (2.2.3)
+    if schema_keys == {"type"}:
+        type_val = schema["type"]
+        if not isinstance(type_val, str) or (type_val not in valid_types):
+            log.debug4("Invalid jtd: Bad type <%s>", type_val)
+            return False
+        return True
+
+    # Enum (2.2.4)
+    if schema_keys == {"enum"}:
+        enum_val = schema["enum"]
+        if (
+            not isinstance(enum_val, list)  # Must be a list
+            or not enum_val  # Must be non-empty
+            or len(set(enum_val)) != len(enum_val)  # Must have no duplicate entries
+        ):
+            log.debug4("Invalid jtd: Bad enum <%s>", enum_val)
+            return False
+        return True
+
+    # Elements (2.2.5)
+    if schema_keys == {"elements"}:
+        elements_val = schema["elements"]
+        if not _is_valid_jtd_impl(elements_val, valid_types, definitions):
+            log.debug4("Invalid jtd: Bad elements <%s>", elements_val)
+            return False
+        return True
+
+    # Properties (2.2.6)
+    if "properties" in schema_keys or "optionalProperties" in schema_keys:
+        properties_val = schema.get("properties", {})
+        opt_properties_val = schema.get("optionalProperties", {})
+        if (
+            # No extra keys beyond additionalProperties
+            schema_keys - {"properties", "optionalProperties", "additionalProperties"}
+            # additionalProperties must be a bool
+            or not isinstance(schema.get("additionalProperties", False), bool)
+            # String dict properties
+            or not _is_string_key_dict(properties_val)
+            # String dict optionalProperties
+            or not _is_string_key_dict(opt_properties_val)
+            # Non-empty
+            or (not properties_val and not opt_properties_val)
+            # No overlapping keys
+            or set(properties_val.keys()).intersection(opt_properties_val.keys())
+            # Valid properties definitions
+            or any(
+                not _is_valid_jtd_impl(val, valid_types, definitions)
+                for val in properties_val.values()
+            )
+            # Valid optionalProperties definitions
+            or any(
+                not _is_valid_jtd_impl(val, valid_types, definitions)
+                for val in opt_properties_val.values()
+            )
+        ):
+            log.debug4(
+                "Invalid jtd: Bad properties <%s> / optionalProperties <%s>",
+                properties_val,
+                opt_properties_val,
+            )
+            return False
+        return True
+
+    # Values (2.2.7)
+    if schema_keys == {"values"}:
+        values_val = schema["values"]
+        if not _is_valid_jtd_impl(values_val, valid_types, definitions):
+            log.debug4("Invalid jtd: Bad 'values' <%s>", values_val)
+            return False
+        return True
+
+    # Discriminator (2.2.8)
+    if schema_keys == {"discriminator", "mapping"}:
+        discriminator_val = schema["discriminator"]
+        mapping_val = schema["mapping"]
+        nullable = schema.get("nullable", False)
+        if (
+            # Discriminator is a string
+            not isinstance(discriminator_val, str)
+            # Mapping is a string dict
+            or not _is_string_key_dict(mapping_val)
+            # Mapping entries are valid JTD
+            or any(
+                not _is_valid_jtd_impl(val, valid_types, definitions)
+                for val in mapping_val.values()
+            )
+            # Mapping entry "nullable" matches discriminator "nullable"
+            or any(
+                val.get("nullable", False) != nullable for val in mapping_val.values()
+            )
+            # Discriminator must not shadow properties in mapping elements
+            or discriminator_val
+            in set.union(
+                *[
+                    set(entry.get("properties", {}).keys())
+                    for entry in mapping_val.values()
+                ],
+                *[
+                    set(entry.get("optionalProperties", {}).keys())
+                    for entry in mapping_val.values()
+                ],
+            )
+        ):
+            log.debug4(
+                "Invalid jtd: Bad discriminator <%s> / mapping <%s>",
+                discriminator_val,
+                mapping_val,
+            )
+            return False
+        return True
+
+    # All other sets of keys are invalid
+    log.debug4("Invalid jtd: Bad key set <%s>", schema_keys)
+    return False
+
+
+def _is_string_key_dict(value: Any) -> bool:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -97,6 +97,9 @@ def test_jtd_to_proto_additonal_properties(temp_dpool):
         {
             "properties": {
                 "buz": {
+                    "properties": {
+                        "blat": {"type": "int8"},
+                    },
                     "additionalProperties": True,
                 },
             },
@@ -114,7 +117,7 @@ def test_jtd_to_proto_additonal_properties(temp_dpool):
     assert nested_types[0].name == "Buz"
     assert nested_types[0].full_name == ".".join([package, msg_name, "Buz"])
     nested_fields = dict(nested_types[0].fields_by_name)
-    assert list(nested_fields.keys()) == ["additionalProperties"]
+    assert set(nested_fields.keys()) == {"blat", "additionalProperties"}
     assert (
         nested_fields["additionalProperties"].type
         == nested_fields["additionalProperties"].TYPE_MESSAGE
@@ -817,7 +820,7 @@ def test_protoc_collision_same_def(temp_dpool):
 
 def test_jtd_to_proto_invalid_def():
     """Make sure that the validation catches an invalid JTD definition"""
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         jtd_to_proto("Foo", "foo.bar", {"foo": "bar"}, validate_jtd=True)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,9 +10,11 @@ import pytest
 import alog
 
 # Local
-from jtd_to_proto.validation import is_valid_jtd
+from jtd_to_proto.validation import _validate_jtd_impl, is_valid_jtd, validate_jtd
 
 log = alog.use_channel("TEST")
+
+## is_valid_jtd ################################################################
 
 VALID_SCHEMAS = [
     # Empty
@@ -143,6 +145,10 @@ INVALID_SCHEMAS = [
             }
         },
     },
+    {
+        "discriminator": "key",
+        "mapping": {"int": {"type": "int32"}, "str": {"type": "string"}},
+    },
 ]
 
 
@@ -158,3 +164,261 @@ def test_invalid_schemas(schema):
     """Make sure all invalid schemas return False as expected"""
     log.debug("Testing invalid schema: %s", schema)
     assert not is_valid_jtd(schema)
+
+
+## validate_jtd ################################################################
+
+
+class CustomClass:
+    pass
+
+
+# (object, schema)
+VALID_JTD = [
+    # Empty
+    ({"foo": 1234, "bar": CustomClass()}, {}),
+    (None, {"nullable": True}),
+    (CustomClass(), {"metadata": {"foo": "bar"}}),
+    # Ref
+    (123, {"definitions": {"a": {"type": "float32"}}, "ref": "a"}),
+    (None, {"definitions": {"a": {"type": "float32"}}, "ref": "a", "nullable": True}),
+    # Type
+    (123, {"type": "int32"}),
+    (123, {"type": "float64"}),
+    (1.23, {"type": "float64"}),
+    (None, {"type": "boolean", "nullable": True}),
+    # Enum
+    ("FOO", {"enum": ["FOO", "BAR"]}),
+    (None, {"enum": ["FOO", "BAR"], "nullable": True}),
+    # Elements
+    ([1, 2], {"elements": {"type": "int32"}}),
+    ([], {"elements": {"type": "int32"}}),
+    (None, {"elements": {"type": "int32"}, "nullable": True}),
+    (
+        [{"foo": 1}, {"foo": 2}],
+        {"elements": {"properties": {"foo": {"type": "int32"}}}},
+    ),
+    # Properties
+    ({"foo": 123}, {"properties": {"foo": {"type": "int32"}}}),
+    ({"foo": ["bar"]}, {"properties": {"foo": {"elements": {"type": "string"}}}}),
+    (
+        {"foo": 123, "bar": "baz"},
+        {"properties": {"foo": {"type": "int32"}, "bar": {"type": "string"}}},
+    ),
+    (
+        {"foo": 123, "bar": "baz"},
+        {
+            "properties": {"foo": {"type": "int32"}},
+            "optionalProperties": {"bar": {"type": "string"}},
+        },
+    ),
+    (
+        {"foo": 123},
+        {
+            "properties": {"foo": {"type": "int32"}},
+            "optionalProperties": {"bar": {"type": "string"}},
+        },
+    ),
+    ({}, {"optionalProperties": {"bar": {"type": "string"}}}),
+    (
+        {"buz": 123},
+        {
+            "optionalProperties": {"bar": {"type": "string"}},
+            "additionalProperties": True,
+        },
+    ),
+    # Values
+    ({"foo": 123, "bar": -2}, {"values": {"type": "int32"}}),
+    ({"foo": {"bar": -2}}, {"values": {"properties": {"bar": {"type": "int32"}}}}),
+    # Discriminator
+    (
+        {"key": "str", "val": "this is a test"},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "int", "val": 123},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "int", "val_int": 123},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val_int": {"type": "int32"}}},
+                "str": {"properties": {"val_str": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "str", "val_str": "asdf"},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val_int": {"type": "int32"}}},
+                "str": {"properties": {"val_str": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "str", "val": "this is a test", "something": "else"},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {
+                    "properties": {"val": {"type": "string"}},
+                    "additionalProperties": True,
+                },
+            },
+        },
+    ),
+]
+
+INVALID_JTD = [
+    # Ref
+    (None, {"definitions": {"a": {"type": "float32"}}, "ref": "a", "nullable": False}),
+    ({"foo": "bar"}, {"definitions": {"a": {"type": "float32"}}, "ref": "a"}),
+    # Type
+    (1.23, {"type": "int8"}),
+    (-2, {"type": "uint8"}),
+    (None, {"type": "boolean"}),
+    # Enum
+    ("BAZ", {"enum": ["FOO", "BAR"]}),
+    (0, {"enum": ["FOO", "BAR"]}),
+    ({}, {"enum": ["FOO", "BAR"]}),
+    (None, {"enum": ["FOO", "BAR"]}),
+    # Elements
+    ([1, 2, "foo"], {"elements": {"type": "int32"}}),
+    (None, {"elements": {"type": "int32"}, "nullable": False}),
+    (
+        [{"foo": 1}, {"foo": 2}],
+        {"elements": {"properties": {"foo": {"type": "string"}}}},
+    ),
+    # Properties
+    ({"foo": 123}, {"properties": {"foo": {"type": "string"}}}),
+    ({"foo": [123]}, {"properties": {"foo": {"elements": {"type": "string"}}}}),
+    (
+        {"bar": "baz"},
+        {"properties": {"foo": {"type": "int32"}, "bar": {"type": "string"}}},
+    ),
+    (
+        {"bar": "baz"},
+        {
+            "properties": {"foo": {"type": "int32"}},
+            "optionalProperties": {"bar": {"type": "string"}},
+        },
+    ),
+    (
+        {},
+        {
+            "properties": {"foo": {"type": "int32"}},
+            "optionalProperties": {"bar": {"type": "string"}},
+        },
+    ),
+    ({"buz": 123}, {"optionalProperties": {"bar": {"type": "string"}}}),
+    (
+        {"buz": 123},
+        {
+            "optionalProperties": {"bar": {"type": "string"}},
+            "additionalProperties": False,
+        },
+    ),
+    ({"bar": 123}, {"optionalProperties": {"bar": {"type": "string"}}}),
+    ([{"foo": 123}], {"properties": {"foo": {"type": "string"}}}),
+    # Values
+    ({"foo": 123, "bar": "asdf"}, {"values": {"type": "int32"}}),
+    ({"foo": {"bar": "test"}}, {"values": {"properties": {"bar": {"type": "int32"}}}}),
+    # Discriminator
+    (
+        {"key": "str", "val": 123},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "int", "val": "asdf"},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        {"key": "str", "val": "this is a test", "something": "else"},
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+    (
+        123,
+        {
+            "discriminator": "key",
+            "mapping": {
+                "int": {"properties": {"val": {"type": "int32"}}},
+                "str": {"properties": {"val": {"type": "string"}}},
+            },
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("obj,schema", VALID_JTD)
+def test_valid_jtd(obj, schema):
+    """Test all valid object validations"""
+    log.debug("Comparing %s to %s", obj, schema)
+    assert validate_jtd(obj, schema)
+
+
+@pytest.mark.parametrize("obj,schema", INVALID_JTD)
+def test_invalid_jtd(obj, schema):
+    """Test all invalid object validations"""
+    log.debug("Comparing %s to %s", obj, schema)
+    assert not validate_jtd(obj, schema)
+
+
+def test_custom_type_validator():
+    """Make sure that a custom type validator works as expected"""
+    assert validate_jtd(
+        CustomClass(),
+        {"type": "CustomClass"},
+        {"CustomClass": lambda x: isinstance(x, CustomClass)},
+    )
+    assert not validate_jtd(
+        123,
+        {"type": "CustomClass"},
+        {"CustomClass": lambda x: isinstance(x, CustomClass)},
+    )
+
+
+def test_validate_jtd_invalid_schema():
+    """Make sure that an invalid schema causes an error in validate_jtd"""
+    with pytest.raises(ValueError):
+        validate_jtd({}, {"not": "a valid schema"})
+
+
+def test_validate_jtd_impl_invalid_schema():
+    """COV! Make sure an error is raised if somehow the schema isn't valid"""
+    with pytest.raises(ValueError):
+        _validate_jtd_impl({}, {"invalid": "schema"}, {})

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,160 @@
+"""
+Unit tests for validation logic. These tests exercise all examples from the RFC
+https://www.rfc-editor.org/rfc/rfc8927
+"""
+
+# Third Party
+import pytest
+
+# First Party
+import alog
+
+# Local
+from jtd_to_proto.validation import is_valid_jtd
+
+log = alog.use_channel("TEST")
+
+VALID_SCHEMAS = [
+    # Empty
+    {},
+    {"nullable": True},
+    {"metadata": {"foo": 12345}},
+    {"definitions": {}},
+    # Ref
+    {
+        "definitions": {
+            "coordinates": {
+                "properties": {"lat": {"type": "float32"}, "lng": {"type": "float32"}}
+            }
+        },
+        "properties": {
+            "user_location": {"ref": "coordinates"},
+            "server_location": {"ref": "coordinates"},
+        },
+    },
+    # Type
+    {"type": "uint8"},
+    # Enum
+    {"enum": ["PENDING", "IN_PROGRESS", "DONE"]},
+    # Elements
+    {"elements": {"type": "uint8"}},
+    # Properties
+    {"optionalProperties": {"foo": {}}},
+    {"optionalProperties": {"foo": {}}, "additionalProperties": True},
+    {
+        "properties": {
+            "users": {
+                "elements": {
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "create_time": {"type": "timestamp"},
+                    },
+                    "optionalProperties": {"delete_time": {"type": "timestamp"}},
+                }
+            },
+            "next_page_token": {"type": "string"},
+        }
+    },
+    # Values
+    {"values": {"type": "uint8"}},
+    # Discriminator
+    {
+        "discriminator": "event_type",
+        "mapping": {
+            "account_deleted": {"properties": {"account_id": {"type": "string"}}},
+            "account_payment_plan_changed": {
+                "properties": {
+                    "account_id": {"type": "string"},
+                    "payment_plan": {"enum": ["FREE", "PAID"]},
+                },
+                "optionalProperties": {"upgraded_by": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "discriminator": "event_type",
+        "nullable": True,
+        "mapping": {
+            "account_deleted": {
+                "nullable": True,
+                "properties": {"account_id": {"type": "string"}},
+            },
+        },
+    },
+]
+
+INVALID_SCHEMAS = [
+    # Empty
+    {"nullable": "foo"},
+    {"metadata": "foo"},
+    # Ref
+    {"ref": "foo"},
+    {"ref": 1234},
+    {"definitions": {"foo": {}}, "ref": "bar"},
+    {"definitions": 1234},
+    {"definitions": {"foo": {"definitions": {}}}},
+    # Type
+    {"type": True},
+    {"type": "foo"},
+    # Enum
+    {"enum": []},
+    {"enum": 1234},
+    {"enum": ["a\\b", "a\u005Cb"]},
+    # Elements
+    {"elements": True},
+    {"elements": {"type": "foo"}},
+    # Properties
+    {
+        "properties": {"confusing": {}},
+        "optionalProperties": {"confusing": {}},
+    },
+    {"optionalProperties": {}},
+    {"properties": {}},
+    {"properties": {}, "optionalProperties": {}},
+    {"properties": 1234},
+    {"optionalProperties": {"foo": {}}, "additionalProperties": 12345},
+    # Values
+    {"values": True},
+    {"values": {"type": "foo"}},
+    # Discriminator
+    {
+        "discriminator": "event_type",
+        "mapping": {
+            "can_the_object_be_null_or_not?": {
+                "nullable": True,
+                "properties": {"foo": {"type": "string"}},
+            }
+        },
+    },
+    {
+        "discriminator": "event_type",
+        "mapping": {
+            "is_event_type_a_string_or_a_float32?": {
+                "properties": {"event_type": {"type": "float32"}}
+            }
+        },
+    },
+    {
+        "discriminator": "event_type",
+        "mapping": {
+            "is_event_type_a_string_or_an_optional_float32?": {
+                "optionalProperties": {"event_type": {"type": "float32"}}
+            }
+        },
+    },
+]
+
+
+@pytest.mark.parametrize("schema", VALID_SCHEMAS)
+def test_valid_schemas(schema):
+    """Make sure all valid schemas return True as expected"""
+    log.debug("Testing valid schema: %s", schema)
+    assert is_valid_jtd(schema)
+
+
+@pytest.mark.parametrize("schema", INVALID_SCHEMAS)
+def test_invalid_schemas(schema):
+    """Make sure all invalid schemas return False as expected"""
+    log.debug("Testing invalid schema: %s", schema)
+    assert not is_valid_jtd(schema)


### PR DESCRIPTION
## Description

This PR adds a local implementation of two `jtd` validation functions:

* `validation.is_valid_jtd`: This will check a given schema dict to ensure that it represents a valid `JTD` schema
* `validation.validat_jtd`: This will check a given object against a given schema

These validation steps replace the validation from the `jtd` package and finish removing the dependency