### PR TITLE
:bug: fix duplicate service def bug

### DIFF
--- a/jtd_to_proto/json_to_service.py
+++ b/jtd_to_proto/json_to_service.py
@@ -21,6 +21,7 @@ from .descriptor_to_message_class import (
     _add_protobuf_serializers,
     descriptor_to_message_class,
 )
+from .jtd_to_proto import _safe_add_fd_to_pool
 from .validation import JTD_TYPE_VALIDATORS, validate_jtd
 
 log = alog.use_channel("JSON2S")
@@ -127,7 +128,7 @@ def json_to_service(
 
     # Add the FileDescriptorProto to the Descriptor Pool
     log.debug("Adding Descriptors to DescriptorPool")
-    descriptor_pool.Add(fd_proto)
+    _safe_add_fd_to_pool(fd_proto, descriptor_pool)
 
     # Return the descriptor for the top-level message
     fullname = name if not package else ".".join([package, name])

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -193,7 +193,9 @@ def _check_service_desc_alignment(
     )
     # Ensure that our service names are the same set
     if d1_service_descs.keys() != d2_service_descs.keys():
-        return False
+        # Excluding from code coverage: We can't actually generate file descriptors with multiple services in them.
+        # But, this check seems pretty basic and worth leaving in if this ever gets extended in the future.
+        return False # pragma: no cover
 
     # For every service, ensure that every method is the same
     for svc_name in d1_service_descs.keys():
@@ -209,8 +211,7 @@ def _are_same_service_descriptor(
     d1_service: descriptor_pb2.ServiceDescriptorProto,
     d2_service: descriptor_pb2.ServiceDescriptorProto,
 ) -> bool:
-    if d1_service.name != d2_service.name:
-        return False
+    # Not checking service.name because we only compare services with the same name
 
     d1_methods = {method.name: method for method in d1_service.method}
     d2_methods = {method.name: method for method in d2_service.method}
@@ -234,21 +235,23 @@ def _are_same_method_descriptor(
     d1_method: descriptor_pb2.MethodDescriptorProto,
     d2_method: descriptor_pb2.MethodDescriptorProto,
 ) -> bool:
-    if d1_method.name != d2_method.name:
-        return False
+    # Not checking method.name because we only compare services with the same name
+
     if not _are_types_similar(d1_method.input_type, d2_method.input_type):
         return False
     if not _are_types_similar(d1_method.output_type, d2_method.output_type):
         return False
+    # TODO: Add the ability for `json_to_service` to set options + streaming settings.
+    # Then we can test this!
     if d1_method.options != d2_method.options:
-        log.debug(
+        log.debug(  # pragma: no cover
             "Method options differ! [%s] vs. [%s]", d1_method.options, d2_method.options
         )
-        return False
+        return False  # pragma: no cover
     if d1_method.client_streaming != d2_method.client_streaming:
-        return False
+        return False  # pragma: no cover
     if d1_method.server_streaming != d2_method.server_streaming:
-        return False
+        return False  # pragma: no cover
     return True
 
 

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -195,7 +195,7 @@ def _check_service_desc_alignment(
     if d1_service_descs.keys() != d2_service_descs.keys():
         # Excluding from code coverage: We can't actually generate file descriptors with multiple services in them.
         # But, this check seems pretty basic and worth leaving in if this ever gets extended in the future.
-        return False # pragma: no cover
+        return False  # pragma: no cover
 
     # For every service, ensure that every method is the same
     for svc_name in d1_service_descs.keys():

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -9,6 +9,7 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import struct_pb2, timestamp_pb2
+import google.protobuf.descriptor_pool
 
 # First Party
 import alog
@@ -32,6 +33,43 @@ def _to_upper_camel(snake_str: str) -> str:
     )
 
 
+def _safe_add_fd_to_pool(
+    fd_proto: descriptor_pb2.FileDescriptorProto,
+    descriptor_pool: google.protobuf.descriptor_pool.DescriptorPool,
+):
+    try:
+        existing_fd = descriptor_pool.FindFileByName(fd_proto.name)
+        # Rebuild the file descriptor proto so that we can compare; there is
+        # almost certainly a more efficient way to compare that avoids this.
+        existing_proto = descriptor_pb2.FileDescriptorProto()
+        existing_fd.CopyToProto(existing_proto)
+        # Raise if the file exists already with different content
+        # Otherwise, do not attempt to re-add the file
+        if not _are_same_file_descriptors(fd_proto, existing_proto):
+            # NOTE: This is a TypeError because that is what you get most of the time when you
+            # have conflict issues in the descriptor pool arising from JTD to Proto followed by
+            # importing differing defs for the same top level message type using different file
+            # names (i.e., skipping this validation) compiled by protoc. Raising TypeError here
+            # ensures that we at least usually raise the same error type regardless of
+            # import / operation order.
+            raise TypeError(
+                f"Cannot add new file {fd_proto.name} to descriptor pool, file already exists with different content"
+            )
+    except KeyError:
+        # It's okay for the file to not already exist, we'll add it!
+        try:
+            descriptor_pool.Add(fd_proto)
+        except TypeError as e:
+            # More likely than not, this is a duplicate symbol; the main case in which
+            # this could occur is when you've compiled files with protoc, added them to your
+            # descriptor pool, and ALSO added the defs in your jtd_to_proto schema, but the
+            # lookup validation with fd_proto.name is skipped because the .proto file fed to
+            # protoc had a different name!
+            raise TypeError(
+                f"Failed to add {fd_proto.name} to descriptor pool with error: [{e}]; Hint: if you previously used protoc to compile this definition, you must recompile it with the name {fd_proto.name} to avoid the conflict."
+            )
+
+
 def _are_same_file_descriptors(
     d1: descriptor_pb2.FileDescriptorProto, d2: descriptor_pb2.FileDescriptorProto
 ) -> bool:
@@ -53,11 +91,13 @@ def _are_same_file_descriptors(
     have_aligned_messages = _check_message_descs_alignment(
         d1.message_type, d2.message_type
     )
+    have_aligned_services = _check_service_desc_alignment(d1.service, d2.service)
     return (
         have_same_deps
         and are_same_package
         and have_aligned_enums
         and have_aligned_messages
+        and have_aligned_services
     )
 
 
@@ -137,6 +177,90 @@ def _check_message_descs_alignment(
         ):
             return False
     return True
+
+
+def _check_service_desc_alignment(
+    d1_service_list: List[descriptor_pb2.ServiceDescriptorProto],
+    d2_service_list: List[descriptor_pb2.ServiceDescriptorProto],
+) -> bool:
+    d1_service_descs = {svc.name: svc for svc in d1_service_list}
+    d2_service_descs = {svc.name: svc for svc in d2_service_list}
+
+    log.debug(
+        "Checking service descriptors: [%s] and [%s]",
+        d1_service_descs,
+        d2_service_descs,
+    )
+    # Ensure that our service names are the same set
+    if d1_service_descs.keys() != d2_service_descs.keys():
+        return False
+
+    # For every service, ensure that every method is the same
+    for svc_name in d1_service_descs.keys():
+        d1_service = d1_service_descs[svc_name]
+        d2_service = d2_service_descs[svc_name]
+
+        if not _are_same_service_descriptor(d1_service, d2_service):
+            return False
+    return True
+
+
+def _are_same_service_descriptor(
+    d1_service: descriptor_pb2.ServiceDescriptorProto,
+    d2_service: descriptor_pb2.ServiceDescriptorProto,
+) -> bool:
+    if d1_service.name != d2_service.name:
+        return False
+
+    d1_methods = {method.name: method for method in d1_service.method}
+    d2_methods = {method.name: method for method in d2_service.method}
+
+    # Ensure that our service names are the same set
+    if d1_methods.keys() != d2_methods.keys():
+        return False
+
+    # For every service, ensure that every method is the same
+    for method_name in d1_methods.keys():
+        d1_method = d1_methods[method_name]
+        d2_method = d2_methods[method_name]
+
+        if not _are_same_method_descriptor(d1_method, d2_method):
+            return False
+
+    return True
+
+
+def _are_same_method_descriptor(
+    d1_method: descriptor_pb2.MethodDescriptorProto,
+    d2_method: descriptor_pb2.MethodDescriptorProto,
+) -> bool:
+    if d1_method.name != d2_method.name:
+        return False
+    if not _are_types_similar(d1_method.input_type, d2_method.input_type):
+        return False
+    if not _are_types_similar(d1_method.output_type, d2_method.output_type):
+        return False
+    if d1_method.options != d2_method.options:
+        log.debug(
+            "Method options differ! [%s] vs. [%s]", d1_method.options, d2_method.options
+        )
+        return False
+    if d1_method.client_streaming != d2_method.client_streaming:
+        return False
+    if d1_method.server_streaming != d2_method.server_streaming:
+        return False
+    return True
+
+
+def _are_types_similar(type_1: str, type_2: str) -> bool:
+    """Returns true iff type names are the same or differ only by a leading `.`"""
+    # TODO: figure out why when you `json_to_service` the same thing twice, on of the service descriptors ends up with
+    # fully qualified names (.foo.bar.Foo) and the other does not (foo.bar.Foo)
+    if type_1 == type_2:
+        return True
+    if type_1.lstrip(".") == type_2.lstrip("."):
+        return True
+    return False
 
 
 def _are_same_message_descriptor(
@@ -290,37 +414,8 @@ def jtd_to_proto(
     if descriptor_pool is None:
         log.debug2("Using default descriptor pool")
         descriptor_pool = _descriptor_pool.Default()
-    try:
-        existing_fd = descriptor_pool.FindFileByName(fd_proto.name)
-        # Rebuild the file descriptor proto so that we can compare; there is
-        # almost certainly a more efficient way to compare that avoids this.
-        existing_proto = descriptor_pb2.FileDescriptorProto()
-        existing_fd.CopyToProto(existing_proto)
-        # Raise if the file exists already with different content
-        # Otherwise, do not attempt to re-add the file
-        if not _are_same_file_descriptors(fd_proto, existing_proto):
-            # NOTE: This is a TypeError because that is what you get most of the time when you
-            # have conflict issues in the descriptor pool arising from JTD to Proto followed by
-            # importing differing defs for the same top level message type using different file
-            # names (i.e., skipping this validation) compiled by protoc. Raising TypeError here
-            # ensures that we at least usually raise the same error type regardless of
-            # import / operation order.
-            raise TypeError(
-                f"Cannot add new file {fd_proto.name} to descriptor pool, file already exists with different content"
-            )
-    except KeyError:
-        # It's okay for the file to not already exist, we'll add it!
-        try:
-            descriptor_pool.Add(fd_proto)
-        except TypeError as e:
-            # More likely than not, this is a duplicate symbol; the main case in which
-            # this could occur is when you've compiled files with protoc, added them to your
-            # descriptor pool, and ALSO added the defs in your jtd_to_proto schema, but the
-            # lookup validation with fd_proto.name is skipped because the .proto file fed to
-            # protoc had a different name!
-            raise TypeError(
-                f"Failed to add {fd_proto.name} to descriptor pool with error: [{e}]; Hint: if you previously used protoc to compile this definition, you must recompile it with the name {fd_proto.name} to avoid the conflict."
-            )
+
+    _safe_add_fd_to_pool(fd_proto, descriptor_pool)
 
     # Return the descriptor for the top-level message
     fullname = name if not package else ".".join([package, name])

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -256,11 +256,7 @@ def _are_types_similar(type_1: str, type_2: str) -> bool:
     """Returns true iff type names are the same or differ only by a leading `.`"""
     # TODO: figure out why when you `json_to_service` the same thing twice, on of the service descriptors ends up with
     # fully qualified names (.foo.bar.Foo) and the other does not (foo.bar.Foo)
-    if type_1 == type_2:
-        return True
-    if type_1.lstrip(".") == type_2.lstrip("."):
-        return True
-    return False
+    return type_1.lstrip(".") == type_2.lstrip(".")
 
 
 def _are_same_message_descriptor(

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -155,45 +155,82 @@ def test_duplicate_services_are_okay(temp_dpool, foo_message, bar_message):
     assert service_descriptor == another_service_descriptor
 
 
-def test_multiple_services_with_the_same_name_are_not_okay(
-    temp_dpool, foo_message, bar_message
-):
-    """Ensure that json can be converted to service descriptor"""
-
-    service_json = {
-        "service": {
-            "rpcs": [
-                {
-                    "name": "FooTrain",
-                    "input_type": "foo.bar.Foo",
-                    "output_type": "foo.bar.Bar",
-                }
-            ]
-        }
+ORIGINAL_SERVICE = {
+    "service": {
+        "rpcs": [
+            {
+                "name": "FooTrain",
+                "input_type": "foo.bar.Foo",
+                "output_type": "foo.bar.Bar",
+            }
+        ]
     }
-    json_to_service(
-        package="foo.bar",
-        name="FooService",
-        json_service_def=service_json,
-        descriptor_pool=temp_dpool,
-    )
-
-    different_service_json = {
+}
+INVALID_DUPLICATE_SERVICES = [
+    {
         "service": {
             "rpcs": [
                 {
-                    "name": "FooPredict",
+                    "name": "FooPredict",  # Different method name
                     "input_type": "foo.bar.Foo",
                     "output_type": "foo.bar.Foo",
                 }
             ]
         }
+    },
+    {
+        "service": {
+            "rpcs": [ # Different number of methods
+                {
+                    "name": "FooPredict",  # Different method name
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Foo",
+                }
+            ]
+        }
+    },
+    {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Bar", # Different input
+                    "output_type": "foo.bar.Bar",
+                }
+            ]
+        }
+    },
+    {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Foo", # Different output
+                }
+            ]
+        }
     }
+]
+
+@pytest.mark.parametrize("schema", INVALID_DUPLICATE_SERVICES)
+def test_multiple_services_with_the_same_name_are_not_okay(
+    schema, temp_dpool, foo_message, bar_message
+):
+    """Ensure that json can be converted to service descriptor"""
+
+    json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=ORIGINAL_SERVICE,
+        descriptor_pool=temp_dpool,
+    )
+
     with pytest.raises(TypeError):
         json_to_service(
             package="foo.bar",
             name="FooService",
-            json_service_def=different_service_json,
+            json_service_def=schema,
             descriptor_pool=temp_dpool,
         )
 

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -183,7 +183,7 @@ INVALID_DUPLICATE_SERVICES = [
             "rpcs": [
                 {
                     "name": "FooTrain",
-                    "input_type": "foo.bar.Bar", # Different input
+                    "input_type": "foo.bar.Bar",  # Different input
                     "output_type": "foo.bar.Bar",
                 }
             ]
@@ -195,12 +195,13 @@ INVALID_DUPLICATE_SERVICES = [
                 {
                     "name": "FooTrain",
                     "input_type": "foo.bar.Foo",
-                    "output_type": "foo.bar.Foo", # Different output
+                    "output_type": "foo.bar.Foo",  # Different output
                 }
             ]
         }
-    }
+    },
 ]
+
 
 @pytest.mark.parametrize("schema", INVALID_DUPLICATE_SERVICES)
 def test_multiple_services_with_the_same_name_are_not_okay(

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -119,6 +119,85 @@ def test_json_to_service_descriptor(temp_dpool, foo_message, bar_message):
     assert len(service_descriptor.methods) == 2
 
 
+def test_duplicate_services_are_okay(temp_dpool, foo_message, bar_message):
+    """Ensure that json can be converted to service descriptor multiple times"""
+
+    service_json = {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Bar",
+                },
+                {
+                    "name": "FooPredict",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Foo",
+                },
+            ]
+        }
+    }
+    # _descriptor.ServiceDescriptor
+    service_descriptor = json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=service_json,
+        descriptor_pool=temp_dpool,
+    )
+
+    another_service_descriptor = json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=service_json,
+        descriptor_pool=temp_dpool,
+    )
+    assert service_descriptor == another_service_descriptor
+
+
+def test_multiple_services_with_the_same_name_are_not_okay(
+    temp_dpool, foo_message, bar_message
+):
+    """Ensure that json can be converted to service descriptor"""
+
+    service_json = {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooTrain",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Bar",
+                }
+            ]
+        }
+    }
+    json_to_service(
+        package="foo.bar",
+        name="FooService",
+        json_service_def=service_json,
+        descriptor_pool=temp_dpool,
+    )
+
+    different_service_json = {
+        "service": {
+            "rpcs": [
+                {
+                    "name": "FooPredict",
+                    "input_type": "foo.bar.Foo",
+                    "output_type": "foo.bar.Foo",
+                }
+            ]
+        }
+    }
+    with pytest.raises(TypeError):
+        json_to_service(
+            package="foo.bar",
+            name="FooService",
+            json_service_def=different_service_json,
+            descriptor_pool=temp_dpool,
+        )
+
+
 def test_json_to_service_input_validation(temp_dpool, foo_message):
     """Make sure that an error is raised if the service definition is invalid"""
     # This def is missing the `input_type` field

--- a/tests/test_json_to_service.py
+++ b/tests/test_json_to_service.py
@@ -180,17 +180,6 @@ INVALID_DUPLICATE_SERVICES = [
     },
     {
         "service": {
-            "rpcs": [ # Different number of methods
-                {
-                    "name": "FooPredict",  # Different method name
-                    "input_type": "foo.bar.Foo",
-                    "output_type": "foo.bar.Foo",
-                }
-            ]
-        }
-    },
-    {
-        "service": {
             "rpcs": [
                 {
                     "name": "FooTrain",


### PR DESCRIPTION
Fixes a bug where a duplicate json_to_service invocation would fail if protobuf was installed with binaries.

(No idea why it worked in the pure python protobuf impl in the first place, but... /shrug)
