### PR TITLE
ValidateDescriptors: Add support for protobuf descriptors as types

### DIFF
--- a/jtd_to_proto/validation.py
+++ b/jtd_to_proto/validation.py
@@ -7,6 +7,9 @@ https://www.rfc-editor.org/rfc/rfc8927
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
+# Third Party
+from google.protobuf import descriptor as _descriptor
+
 # First Party
 import alog
 
@@ -144,7 +147,13 @@ def _is_valid_jtd_impl(
     # Type (2.2.3)
     if schema_keys == {"type"}:
         type_val = schema["type"]
-        if not isinstance(type_val, str) or (type_val not in valid_types):
+        if (
+            # All protobuf descriptors are "special" cases
+            not isinstance(type_val, _descriptor.Descriptor)
+            and
+            # All non-descriptor types must be valid types
+            (not isinstance(type_val, str) or (type_val not in valid_types))
+        ):
             log.debug4("Invalid jtd: Bad type <%s>", type_val)
             return False
         return True

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,11 +10,17 @@ import pytest
 import alog
 
 # Local
+from jtd_to_proto.jtd_to_proto import jtd_to_proto
 from jtd_to_proto.validation import _validate_jtd_impl, is_valid_jtd, validate_jtd
 
 log = alog.use_channel("TEST")
 
 ## is_valid_jtd ################################################################
+
+SampleDescriptor = jtd_to_proto(
+    "Sample", "foo.bar", {"properties": {"foo": {"type": "string"}}}
+)
+
 
 VALID_SCHEMAS = [
     # Empty
@@ -36,6 +42,7 @@ VALID_SCHEMAS = [
     },
     # Type
     {"type": "uint8"},
+    {"type": SampleDescriptor},
     # Enum
     {"enum": ["PENDING", "IN_PROGRESS", "DONE"]},
     # Elements


### PR DESCRIPTION
## Description

This PR fixes the validation functions so that types can reference pre-existing protobuf descriptors