### PR TITLE
Fix backwards compat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,3 +91,11 @@ jobs:
               run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PROTOBUF_VERSION=">=3.19.0,<3.20"
               env:
                   PYTHON_VERSION: "3.8"
+    build-38-pb320:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Run unit tests
+              run: docker build . --target=test --build-arg PYTHON_VERSION=${PYTHON_VERSION} --build-arg PROTOBUF_VERSION=">=3.20.0,<3.21"
+              env:
+                  PYTHON_VERSION: "3.8"

--- a/jtd_to_proto/descriptor_to_message_class.py
+++ b/jtd_to_proto/descriptor_to_message_class.py
@@ -46,7 +46,7 @@ def descriptor_to_message_class(
         #   this is needed here.
         try:
             message_class = descriptor._concrete_class
-        except (TypeError, SystemError):
+        except (TypeError, SystemError, AttributeError):
             message_class = reflection.message_factory.MessageFactory().GetPrototype(
                 descriptor
             )


### PR DESCRIPTION
## Description

This PR adds to #39 to support protobuf 3.20 where `Descriptor._concrete_class` didn't exist at all