### PR TITLE
Support `optionalProperties`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 htmlcov
 __pycache__
 *.egg-info/
+build/
 dist/
 .DS_Store
 .pytest_cache

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -551,9 +551,9 @@ def _jtd_to_proto_impl(
     additional_properties = jtd_def.get("additionalProperties")
     if all_properties or additional_properties:
         field_descriptors: List[descriptor_pb2.FieldDescriptorProto] = []
-        nested_enums = []
-        nested_messages = []
-        nested_oneofs = []
+        nested_enums: List[descriptor_pb2.EnumDescriptorProto] = []
+        nested_messages: List[descriptor_pb2.DescriptorProto] = []
+        nested_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
 
         # Iterate each field and perform the recursive conversion
         for field_index, (field_name, field_def) in enumerate(all_properties.items()):

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -548,7 +548,14 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
     # Validate nested descriptors
     assert not descriptor.nested_types
     assert not descriptor.enum_types
-    assert not descriptor.oneofs
+    # The one optional property will have its field nested inside a `oneof` as well
+    assert len(descriptor.oneofs) == 1
+    # The oneof's name has a leading underscore
+    assert descriptor.oneofs[0].name == "_metoo"
+    assert descriptor.oneofs[0].full_name == ".".join([descriptor.full_name, "_metoo"])
+    # This `oneof` is a bit degenerate: it only contains the single field.
+    # It's only used to check if the field was supplied or not
+    assert len(descriptor.oneofs[0].fields) == 1
 
     # Validate fields
     fields = dict(descriptor.fields_by_name)
@@ -557,6 +564,9 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
     assert fields["foo"].label == fields["foo"].LABEL_OPTIONAL
     assert fields["metoo"].type == fields["metoo"].TYPE_STRING
     assert fields["metoo"].label == fields["metoo"].LABEL_OPTIONAL
+
+    # Make sure the optional field has the same field descriptor at the top level of the message and in the oneof
+    assert fields["metoo"] is descriptor.oneofs[0].fields[0]
 
 
 def test_jtd_to_proto_top_level_enum(temp_dpool):


### PR DESCRIPTION
Closes https://github.com/IBM/jtd-to-proto/issues/34

This PR extends the functionality that implements the field descriptors for `optionalProperties` inside messages.
For these optional properties, a `oneof` is added which contains a single field which is the field descriptor for that optional property 🤯 

This mimics how `protoc` creates message descriptors, if you inspect one compiled with an optional field you'll see a oneof with a single field inside it.
