### PR TITLE
Render optional fields

### DIFF
--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -226,10 +226,7 @@ def _field_descriptor_to_file(
         field_line += "repeated "
 
     # Add the optional qualifier if needed
-    if (
-        field_descriptor.containing_oneof
-        and _is_optional_field_oneof(field_descriptor.containing_oneof)
-    ):
+    if _is_optional_field_oneof(field_descriptor.containing_oneof):
         field_line += "optional "
 
     # Add the type
@@ -284,4 +281,8 @@ def _is_map_entry(message_descriptor: _descriptor.Descriptor) -> bool:
 def _is_optional_field_oneof(oneof_descriptor: Optional[_descriptor.OneofDescriptor]):
     """Check whether the oneof is an internal detail for dealing with an optional
     field, rather than an explicit oneof in the message description"""
-    return oneof_descriptor and len(oneof_descriptor.fields) == 1 and oneof_descriptor.name.startswith("_")
+    return (
+        oneof_descriptor
+        and len(oneof_descriptor.fields) == 1
+        and oneof_descriptor.name.startswith("_")
+    )

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -4,7 +4,7 @@ This module implements serialization of an in-memory Descriptor to a portable
 """
 
 # Standard
-from typing import List, Union
+from typing import List, Optional, Union
 
 # Third Party
 from google.protobuf import descriptor as _descriptor

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -212,8 +212,8 @@ def _field_descriptor_to_file(
         and field_descriptor.label == field_descriptor.LABEL_REPEATED
     ):
         field_line += "repeated "
-    # elif optional:
-        # field_line += "optional "
+    if field_descriptor.containing_oneof and len(field_descriptor.containing_oneof.fields) == 1 and field_descriptor.containing_oneof.name.startswith("_"):
+        field_line += "optional "
 
     # Add the type
     field_line += _get_field_type_str(field_descriptor)

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -212,6 +212,8 @@ def _field_descriptor_to_file(
         and field_descriptor.label == field_descriptor.LABEL_REPEATED
     ):
         field_line += "repeated "
+    # elif optional:
+        # field_line += "optional "
 
     # Add the type
     field_line += _get_field_type_str(field_descriptor)

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -281,7 +281,7 @@ def _is_map_entry(message_descriptor: _descriptor.Descriptor) -> bool:
     )
 
 
-def _is_optional_field_oneof(oneof_descriptor: _descriptor.OneofDescriptor):
+def _is_optional_field_oneof(oneof_descriptor: Optional[_descriptor.OneofDescriptor]):
     """Check whether the oneof is an internal detail for dealing with an optional
     field, rather than an explicit oneof in the message description"""
-    return len(oneof_descriptor.fields) == 1 and oneof_descriptor.name.startswith("_")
+    return oneof_descriptor and len(oneof_descriptor.fields) == 1 and oneof_descriptor.name.startswith("_")

--- a/jtd_to_proto/descriptor_to_file.py
+++ b/jtd_to_proto/descriptor_to_file.py
@@ -224,10 +224,11 @@ def _field_descriptor_to_file(
         and field_descriptor.label == field_descriptor.LABEL_REPEATED
     ):
         field_line += "repeated "
+
+    # Add the optional qualifier if needed
     if (
         field_descriptor.containing_oneof
-        and len(field_descriptor.containing_oneof.fields) == 1
-        and field_descriptor.containing_oneof.name.startswith("_")
+        and _is_optional_field_oneof(field_descriptor.containing_oneof)
     ):
         field_line += "optional "
 

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -729,7 +729,10 @@ def _jtd_to_proto_impl(
         # becomes interpreted as oneof _foo { int32 foo = 1; }
         optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
         for field in field_descriptors:
-            if field.name in optional_properties.keys() and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL:
+            if (
+                field.name in optional_properties.keys()
+                and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL
+            ):
                 # OneofDescriptorProto do not contain fields themselves. Instead the
                 # FieldDescriptorProto must contain the index of the oneof inside the
                 # DescriptorProto

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -729,7 +729,7 @@ def _jtd_to_proto_impl(
         # becomes interpreted as oneof _foo { int32 foo = 1; }
         optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
         for field in field_descriptors:
-            if field.name in optional_properties.keys():
+            if field.name in optional_properties.keys() and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL:
                 # OneofDescriptorProto do not contain fields themselves. Instead the
                 # FieldDescriptorProto must contain the index of the oneof inside the
                 # DescriptorProto

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -115,15 +115,22 @@ sample_jtd_def = jtd_def = {
     },
     # optionalProperties are also handled as properties
     "optionalProperties": {
-        "metoo": {
+        # Optional primitive
+        "optionalString": {
             "type": "string",
-        }
+        },
+        # Optional array
+        "optionalList": {
+            "elements": {
+                "type": "string",
+            }
+        },
     },
 }
 
 
 def compile_proto_module(
-    proto_content: str, imported_file_contents: Dict[str, str] = None
+        proto_content: str, imported_file_contents: Dict[str, str] = None
 ) -> Optional[ModuleType]:
     """Compile the proto file content locally"""
     with tempfile.TemporaryDirectory() as dirname:
@@ -243,6 +250,23 @@ def test_descriptor_to_file_enum_descriptor(temp_dpool):
     )
     res = descriptor_to_file(enum_descriptor)
     assert "enum Foo {" in res
+
+
+def test_descriptor_to_file_optional_properties(temp_dpool):
+    """Make sure descriptor_to_file sticks `optional` in front of optional fields"""
+    raw_protobuf = descriptor_to_file(
+        jtd_to_proto(
+            "Widgets",
+            "foo.bar.baz.bat",
+            sample_jtd_def,
+            descriptor_pool=temp_dpool,
+            validate_jtd=True,
+        )
+    )
+    # Non-array things in `optionalProperties` should have `optional`
+    assert any("optional string optionalString" in line for line in raw_protobuf)
+    # But fields cannot be both `repeated` and `optional`
+    assert any("repeated string optionalList" in line for line in raw_protobuf)
 
 
 def test_descriptor_to_file_service_descriptor(temp_dpool):

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -130,7 +130,7 @@ sample_jtd_def = jtd_def = {
 
 
 def compile_proto_module(
-        proto_content: str, imported_file_contents: Dict[str, str] = None
+    proto_content: str, imported_file_contents: Dict[str, str] = None
 ) -> Optional[ModuleType]:
     """Compile the proto file content locally"""
     with tempfile.TemporaryDirectory() as dirname:
@@ -263,10 +263,15 @@ def test_descriptor_to_file_optional_properties(temp_dpool):
             validate_jtd=True,
         )
     )
+    raw_protobuf_lines = raw_protobuf.splitlines()
     # Non-array things in `optionalProperties` should have `optional`
-    assert any("optional string optionalString" in line for line in raw_protobuf), f"optionalString not in {raw_protobuf}"
+    assert any(
+        "optional string optionalString" in line for line in raw_protobuf_lines
+    ), f"optionalString not in {raw_protobuf}"
     # But fields cannot be both `repeated` and `optional`
-    assert any("repeated string optionalList" in line for line in raw_protobuf), f"optionalList broken in {raw_protobuf}"
+    assert any(
+        "repeated string optionalList" in line for line in raw_protobuf_lines
+    ), f"optionalList broken in {raw_protobuf}"
 
 
 def test_descriptor_to_file_service_descriptor(temp_dpool):

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -272,6 +272,8 @@ def test_descriptor_to_file_optional_properties(temp_dpool):
     assert any(
         "repeated string optionalList" in line for line in raw_protobuf_lines
     ), f"optionalList broken in {raw_protobuf}"
+    # Additionally, check that the internal oneof was not rendered
+    assert "_optionalString" not in raw_protobuf
 
 
 def test_descriptor_to_file_service_descriptor(temp_dpool):

--- a/tests/test_descriptor_to_file.py
+++ b/tests/test_descriptor_to_file.py
@@ -264,9 +264,9 @@ def test_descriptor_to_file_optional_properties(temp_dpool):
         )
     )
     # Non-array things in `optionalProperties` should have `optional`
-    assert any("optional string optionalString" in line for line in raw_protobuf)
+    assert any("optional string optionalString" in line for line in raw_protobuf), f"optionalString not in {raw_protobuf}"
     # But fields cannot be both `repeated` and `optional`
-    assert any("repeated string optionalList" in line for line in raw_protobuf)
+    assert any("repeated string optionalList" in line for line in raw_protobuf), f"optionalList broken in {raw_protobuf}"
 
 
 def test_descriptor_to_file_service_descriptor(temp_dpool):

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -533,8 +533,13 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
                 },
             },
             "optionalProperties": {
-                "metoo": {
+                "optionalFoo": {
                     "type": "string",
+                },
+                "optionalList": {
+                    "elements": {
+                        "type": "string"
+                    }
                 }
             },
         },
@@ -548,25 +553,27 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
     # Validate nested descriptors
     assert not descriptor.nested_types
     assert not descriptor.enum_types
-    # The one optional property will have its field nested inside a `oneof` as well
+    # The optional property will have its field nested inside a `oneof` as well
+    # 🌶️🌶️🌶️ Only the `optionalFoo` field gets this special `oneof`.
+    # Repeated fields (optionalList) do not get the nested oneof wrapping
     assert len(descriptor.oneofs) == 1
     # The oneof's name has a leading underscore
-    assert descriptor.oneofs[0].name == "_metoo"
-    assert descriptor.oneofs[0].full_name == ".".join([descriptor.full_name, "_metoo"])
+    assert descriptor.oneofs[0].name == "_optionalFoo"
+    assert descriptor.oneofs[0].full_name == ".".join([descriptor.full_name, "_optionalFoo"])
     # This `oneof` is a bit degenerate: it only contains the single field.
     # It's only used to check if the field was supplied or not
     assert len(descriptor.oneofs[0].fields) == 1
 
     # Validate fields
     fields = dict(descriptor.fields_by_name)
-    assert list(fields.keys()) == ["foo", "metoo"]
+    assert list(fields.keys()) == ["foo", "optionalFoo"]
     assert fields["foo"].type == fields["foo"].TYPE_BOOL
     assert fields["foo"].label == fields["foo"].LABEL_OPTIONAL
-    assert fields["metoo"].type == fields["metoo"].TYPE_STRING
-    assert fields["metoo"].label == fields["metoo"].LABEL_OPTIONAL
+    assert fields["optionalFoo"].type == fields["optionalFoo"].TYPE_STRING
+    assert fields["optionalFoo"].label == fields["optionalFoo"].LABEL_OPTIONAL
 
     # Make sure the optional field has the same field descriptor at the top level of the message and in the oneof
-    assert fields["metoo"] is descriptor.oneofs[0].fields[0]
+    assert fields["optionalFoo"] is descriptor.oneofs[0].fields[0]
 
 
 def test_jtd_to_proto_top_level_enum(temp_dpool):

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -536,11 +536,7 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
                 "optionalFoo": {
                     "type": "string",
                 },
-                "optionalList": {
-                    "elements": {
-                        "type": "string"
-                    }
-                }
+                "optionalList": {"elements": {"type": "string"}},
             },
         },
         descriptor_pool=temp_dpool,
@@ -559,7 +555,9 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
     assert len(descriptor.oneofs) == 1
     # The oneof's name has a leading underscore
     assert descriptor.oneofs[0].name == "_optionalFoo"
-    assert descriptor.oneofs[0].full_name == ".".join([descriptor.full_name, "_optionalFoo"])
+    assert descriptor.oneofs[0].full_name == ".".join(
+        [descriptor.full_name, "_optionalFoo"]
+    )
     # This `oneof` is a bit degenerate: it only contains the single field.
     # It's only used to check if the field was supplied or not
     assert len(descriptor.oneofs[0].fields) == 1

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -566,7 +566,7 @@ def test_jtd_to_proto_optional_properties(temp_dpool):
 
     # Validate fields
     fields = dict(descriptor.fields_by_name)
-    assert list(fields.keys()) == ["foo", "optionalFoo"]
+    assert list(fields.keys()) == ["foo", "optionalFoo", "optionalList"]
     assert fields["foo"].type == fields["foo"].TYPE_BOOL
     assert fields["foo"].label == fields["foo"].LABEL_OPTIONAL
     assert fields["optionalFoo"].type == fields["optionalFoo"].TYPE_STRING


### PR DESCRIPTION
Closes https://github.com/IBM/jtd-to-proto/issues/43

Also fixes a bug where putting a list in `optionalProperties` would break

This PR adds special handling in the `descriptor_to_file` function to detect internal oneofs that were added to support optional fields. (These oneofs only have a single field in them, and all start with `_`)

This ensures that both:
- These internal oneofs are not explicitly rendered to protobuf, and
- The fields in these oneofs are explictly rendered, with the `optional` keyword in front