### PR TITLE
Schema to proto abstraction

### DIFF
--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -293,6 +293,7 @@ class ConverterBase(Generic[T], abc.ABC):
                 type=key_type,
                 number=1,
             )
+            val_field_kwargs = {}
             msg_descriptor_kwargs = {}
             if isinstance(val_type, int):
                 val_field_kwargs = {"type": val_type}
@@ -318,8 +319,9 @@ class ConverterBase(Generic[T], abc.ABC):
                     "type_name": val_type.name,
                 }
                 msg_descriptor_kwargs["nested_type"] = [val_type]
-            else:
-                raise ValueError(f"Got unhandled map value type: {val_type}")
+            assert (
+                val_field_kwargs
+            ), f"Programming Error: Got unhandled map value type: {val_type}"
             val_field = descriptor_pb2.FieldDescriptorProto(
                 name="value",
                 number=2,

--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -215,10 +215,16 @@ class ConverterBase(Generic[T], abc.ABC):
     def _convert(
         self, entry: Any, name: str
     ) -> Union[
+        # Nested message
         descriptor_pb2.DescriptorProto,
+        # Nested enum
         descriptor_pb2.EnumDescriptorProto,
+        # Concrete primitive type enum value
         int,
-        Tuple[str, int],
+        # Concrete message type reference
+        _descriptor.Descriptor,
+        # Concrete enum type reference
+        _descriptor.EnumDescriptor,
     ]:
         """This is the core recursive implementation detail function that does
         the common conversion logic for all converters.
@@ -239,7 +245,7 @@ class ConverterBase(Generic[T], abc.ABC):
 
         # Handle concrete types
         #
-        # Returns: Union[int, Descriptor]
+        # Returns: Union[int, _descriptor.Descriptor, _descriptor.EnumDescriptor]
         concrete_type = self.get_concrete_type(entry)
         if concrete_type:
             log.debug2("Handling concrete type: %s", concrete_type)

--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -1,0 +1,579 @@
+"""
+This base class provides the abstract interface that needs to be implemented to
+convert from some schema format into a protobuf descriptor. It also implements
+the common conversion scaffolding that all converters will use to create the
+descriptor.
+"""
+
+# Standard
+from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
+import abc
+import copy
+
+# Third Party
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pb2
+from google.protobuf import descriptor_pool as _descriptor_pool
+from google.protobuf import struct_pb2
+
+# First Party
+import alog
+
+# Local
+from .utils import safe_add_fd_to_pool, to_upper_camel
+
+T = TypeVar("T")
+
+
+log = alog.use_channel("2PCVRT")
+
+
+# Top level descriptor types
+_DescriptorTypes = (_descriptor.Descriptor, _descriptor.EnumDescriptor)
+_DescriptorTypesUnion = Union[_descriptor.Descriptor, _descriptor.EnumDescriptor]
+
+
+class ConverterBase(Generic[T], abc.ABC):
+    __doc__ = __doc__
+
+    def __init__(
+        self,
+        name: str,
+        package: str,
+        source_schema: T,
+        type_mapping: Dict[Any, Union[int, _descriptor.Descriptor]],
+        validate: bool,
+        descriptor_pool: Optional[_descriptor_pool.DescriptorPool],
+    ):
+        """This class performs its work on initialization by invoking the
+        abstract methods that the child class will implement.
+
+        Args:
+            name (str)
+                The name for the top-level message or enum descriptor
+            package (str)
+                The proto package name to use for this object
+            source_schema (T)
+                The source schema object for the derived converter
+            type_mapping (Dict[Any, Union[int, _descriptor.Descriptor]])
+                A mapping from how types are represented in T to the protobuf
+                type enum and/or Descriptor to be used to represent the type in
+                proto.
+            validate (bool)
+                Whether or not to perform validation before attempting
+                conversion
+            descriptor_pool (Optional[_descriptor_pool.DescriptorPool])
+                An explicit descriptor pool to use for the new descriptor
+        """
+        # Set up the shared members for this converter
+        self.type_mapping = type_mapping
+        self.package = package
+        self.imports = set()
+
+        # Perform validation if requested
+        if validate:
+            log.debug2("Validating")
+            if not self.validate(source_schema):
+                raise ValueError(f"Invalid Schema: {source_schema}")
+
+        # Perform the recursive conversion to update the descriptors and enums in
+        # place
+        log.debug("Performing conversion")
+        descriptor_proto = self._convert(entry=source_schema, name=name)
+        proto_kwargs = {}
+        is_enum = False
+        if isinstance(descriptor_proto, descriptor_pb2.DescriptorProto):
+            proto_kwargs["message_type"] = [descriptor_proto]
+        elif isinstance(descriptor_proto, descriptor_pb2.EnumDescriptorProto):
+            is_enum = True
+            proto_kwargs["enum_type"] = [descriptor_proto]
+        else:
+            raise ValueError("Only messages and enums are supported")
+
+        # Create the FileDescriptorProto with all messages
+        log.debug("Creating FileDescriptorProto")
+        fd_proto = descriptor_pb2.FileDescriptorProto(
+            name=f"{name.lower()}.proto",
+            package=package,
+            syntax="proto3",
+            dependency=sorted(list(self.imports)),
+            **proto_kwargs,
+        )
+        log.debug4("Full FileDescriptorProto:\n%s", fd_proto)
+
+        # Add the new file descriptor to the pool
+        log.debug("Adding Descriptors to DescriptorPool")
+        if descriptor_pool is None:
+            log.debug2("Using default descriptor pool")
+            descriptor_pool = _descriptor_pool.Default()
+        safe_add_fd_to_pool(fd_proto, descriptor_pool)
+
+        # Return the descriptor for the top-level message
+        fullname = name if not package else ".".join([package, name])
+        if is_enum:
+            self.descriptor = descriptor_pool.FindEnumTypeByName(fullname)
+        else:
+            self.descriptor = descriptor_pool.FindMessageTypeByName(fullname)
+
+    ## Abstract Interface ######################################################
+
+    @abc.abstractmethod
+    def validate(self, source_schema: T) -> bool:
+        """Perform preprocess validation of the input"""
+
+    ## Types ##
+
+    @abc.abstractmethod
+    def get_concrete_type(self, entry: Any) -> Any:
+        """If this is a concrete type, get the type map key for it"""
+
+    ## Maps ##
+
+    @abc.abstractmethod
+    def get_map_key_val_types(
+        self,
+        entry: Any,
+    ) -> Optional[Tuple[int, Union[int, _descriptor.Descriptor]]]:
+        """Get the key and value types for a given map type"""
+
+    ## Enums ##
+
+    @abc.abstractmethod
+    def get_enum_vals(self, entry: Any) -> Optional[List[Tuple[str, int]]]:
+        """Get the ordered list of enum name -> number mappings if this entry is
+        an enum
+
+        NOTE: If any values appear multiple times, this implies an alias
+
+        NOTE 2: All names must be unique
+        """
+
+    ## Messages ##
+
+    @abc.abstractmethod
+    def get_message_fields(self, entry: Any) -> Optional[Iterable[Tuple[str, Any]]]:
+        """Get the mapping of names to type-specific field descriptors if this
+        entry is a message
+        """
+
+    @abc.abstractmethod
+    def has_additional_fields(self, entry: Any) -> bool:
+        """Check whether the given entry expects to support arbitrary key/val
+        additional properties
+        """
+
+    @abc.abstractmethod
+    def get_optional_field_names(self, entry: Any) -> List[str]:
+        """Get the names of any fields which are explicitly marked 'optional'"""
+
+    ## Fields ##
+
+    @abc.abstractmethod
+    def get_field_number(self, num_fields: int, field_def: Any) -> int:
+        """From the given field definition and index, get the proto field number"""
+
+    @abc.abstractmethod
+    def get_oneof_fields(self, field_def: Any) -> Optional[Iterable[Tuple[str, Any]]]:
+        """If the given field is a oneof, return an iterable of the sub-field
+        definitions
+        """
+
+    @abc.abstractmethod
+    def get_oneof_name(self, field_def: Any) -> str:
+        """For an identified oneof field def, get the name"""
+
+    @abc.abstractmethod
+    def get_field_type(self, field_def: Any) -> Any:
+        """Get the type of the field. The definition of type here will be
+        specific to the converter (e.g. string for JTD, py type for dataclass)
+        """
+
+    @abc.abstractmethod
+    def is_repeated_field(self, field_def: Any) -> bool:
+        """Determine if the given field def is repeated"""
+
+    ## Implementation Details ##################################################
+
+    def get_descriptor(self, entry: Any) -> Optional[_DescriptorTypesUnion]:
+        """Given an entry, try to get a pre-existing descriptor from it. Child
+        classes may overwrite this for alternate converters that have other
+        known ways of getting a descriptor beyond these basics.
+        """
+        if isinstance(entry, _DescriptorTypes):
+            return entry
+        descriptor_attr = getattr(entry, "DESCRIPTOR", None)
+        if descriptor_attr and isinstance(descriptor_attr, _DescriptorTypes):
+            return descriptor_attr
+        return None
+
+    def _add_descriptor_imports(self, descriptor: _DescriptorTypesUnion):
+        """Helper to add the descriptor's file to the required imports"""
+        import_file = descriptor.file.name
+        log.debug3("Adding import file %s", import_file)
+        self.imports.add(import_file)
+
+    def _convert(
+        self, entry: Any, name: str
+    ) -> Union[
+        descriptor_pb2.DescriptorProto,
+        descriptor_pb2.EnumDescriptorProto,
+        int,
+        Tuple[str, int],
+    ]:
+        """This is the core recursive implementation detail function that does
+        the common conversion logic for all converters.
+        """
+
+        # Common logic for determining the name to use if a name is needed
+        message_name = to_upper_camel(name)
+        log.debug("Message name: %s", message_name)
+
+        # Handle descriptor references
+        #
+        # Returns: Descriptor
+        descriptor_ref = self.get_descriptor(entry)
+        if descriptor_ref is not None:
+            log.debug2("Handling direct descriptor reference")
+            self._add_descriptor_imports(descriptor_ref)
+            return descriptor_ref
+
+        # Handle concrete types
+        #
+        # Returns: Union[int, Descriptor]
+        concrete_type = self.get_concrete_type(entry)
+        if concrete_type:
+            log.debug2("Handling concrete type: %s", concrete_type)
+            entry_type = self.type_mapping.get(concrete_type, concrete_type)
+            proto_type_descriptor = None
+            descriptor_ref = self.get_descriptor(entry_type)
+            if descriptor_ref is not None:
+                proto_type_descriptor = descriptor_ref
+            else:
+                if concrete_type not in self.type_mapping:
+                    raise ValueError(f"Invalid type specifier: {concrete_type}")
+                proto_type_val = self.type_mapping[concrete_type]
+                proto_type_descriptor = getattr(proto_type_val, "DESCRIPTOR", None)
+                if proto_type_descriptor is None:
+                    if not isinstance(proto_type_val, int):
+                        raise ValueError(
+                            "All proto_type_map values must be Descriptors or int"
+                        )
+                    proto_type_descriptor = proto_type_val
+
+            # If this is a non-primitive type, make sure any import files are added
+            if isinstance(proto_type_descriptor, _DescriptorTypes):
+                self._add_descriptor_imports(proto_type_descriptor)
+            log.debug3("Returning type %s", proto_type_descriptor)
+            return proto_type_descriptor
+
+        # Handle Dicts
+        #
+        # If this is a Dict, handle it by making the "special"
+        # submessage and then making this field's type be that
+        # submessage
+        #
+        # Maps in descriptors are implemented in a _funky_ way. The map
+        # syntax
+        #     map<KeyType, ValType> the_map = 1;
+        #
+        # gets converted to a repeated message as follows:
+        #     option map_entry = true;
+        #     optional KeyType key = 1;
+        #     optional ValType value = 2;
+        #
+        # CITE: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L7512
+        #
+        # Returns: descriptor_pb2.DescriptorProto
+        ##
+        map_info = self.get_map_key_val_types(entry)
+        if map_info:
+            log.debug2("Handling map type: %s", entry)
+            key_type, val_type = map_info
+            nested_cls_name = f"{to_upper_camel(name)}Entry"
+            log.debug3("Making nested map<> class: %s", nested_cls_name)
+            key_field = descriptor_pb2.FieldDescriptorProto(
+                name="key",
+                type=key_type,
+                number=1,
+            )
+            msg_descriptor_kwargs = {}
+            if isinstance(val_type, int):
+                val_field_kwargs = {"type": val_type}
+            elif isinstance(val_type, _descriptor.EnumDescriptor):
+                val_field_kwargs = {
+                    "type": _descriptor.FieldDescriptor.TYPE_ENUM,
+                    "type_name": val_type.name,
+                }
+            elif isinstance(val_type, _descriptor.Descriptor):
+                val_field_kwargs = {
+                    "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
+                    "type_name": val_type.name,
+                }
+            elif isinstance(val_type, descriptor_pb2.EnumDescriptorProto):
+                val_field_kwargs = {
+                    "type": _descriptor.FieldDescriptor.TYPE_ENUM,
+                    "type_name": val_type.name,
+                }
+                msg_descriptor_kwargs["enum_type"] = [val_type]
+            elif isinstance(val_type, descriptor_pb2.DescriptorProto):
+                val_field_kwargs = {
+                    "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
+                    "type_name": val_type.name,
+                }
+                msg_descriptor_kwargs["nested_type"] = [val_type]
+            else:
+                raise ValueError(f"Got unhandled map value type: {val_type}")
+            val_field = descriptor_pb2.FieldDescriptorProto(
+                name="value",
+                number=2,
+                **val_field_kwargs,
+            )
+            nested = descriptor_pb2.DescriptorProto(
+                name=nested_cls_name,
+                field=[key_field, val_field],
+                options=descriptor_pb2.MessageOptions(map_entry=True),
+                **msg_descriptor_kwargs,
+            )
+            return nested
+
+        # Handle enums
+        #
+        # Returns: descriptor_pb2.EnumDescriptorProto
+        enum_entries = self.get_enum_vals(entry)
+        if enum_entries is not None:
+            log.debug2("Handling Enum: %s", entry)
+            has_aliases = len(set([entry[1] for entry in enum_entries])) != len(
+                enum_entries
+            )
+            options = descriptor_pb2.EnumOptions(allow_alias=has_aliases)
+            enum_proto = descriptor_pb2.EnumDescriptorProto(
+                name=message_name,
+                value=[
+                    descriptor_pb2.EnumValueDescriptorProto(
+                        name=entry[0],
+                        number=entry[1],
+                    )
+                    for entry in enum_entries
+                ],
+                options=options,
+            )
+            return enum_proto
+
+        # Handle messages
+        #
+        # Returns: descriptor_pb2.DescriptorProto
+        message_fields = self.get_message_fields(entry)
+        if message_fields is not None:
+            log.debug2("Handling Message")
+            field_descriptors = []
+            nested_enums = []
+            nested_messages = []
+            nested_oneofs = []
+
+            for field_name, field_def in message_fields:
+                field_number = self.get_field_number(len(field_descriptors), field_def)
+                log.debug2(
+                    "Handling field [%s.%s] (%d)",
+                    message_name,
+                    field_name,
+                    field_number,
+                )
+
+                # Get the field's number
+                field_kwargs = {
+                    "name": field_name,
+                    "number": field_number,
+                    "label": _descriptor.FieldDescriptor.LABEL_OPTIONAL,
+                }
+
+                # Check to see if the field is repeated
+                if self.is_repeated_field(field_def):
+                    log.debug3("Handling repeated field %s", field_name)
+                    field_kwargs["label"] = _descriptor.FieldDescriptor.LABEL_REPEATED
+
+                # If the field is a oneof, handle it as such
+                oneof_fields = self.get_oneof_fields(field_def)
+                if oneof_fields:
+                    log.debug2("Handling oneof field %s", field_name)
+                    nested_results = [
+                        (
+                            self._convert(entry=oneof_field_def, name=oneof_field_name),
+                            {
+                                "oneof_index": len(nested_oneofs),
+                                "number": self.get_field_number(
+                                    len(field_descriptors) + oneof_field_idx,
+                                    oneof_field_def,
+                                ),
+                                "name": oneof_field_name.lower(),
+                            },
+                        )
+                        for oneof_field_idx, (
+                            oneof_field_name,
+                            oneof_field_def,
+                        ) in enumerate(oneof_fields)
+                    ]
+                    # Add the name for this oneof
+                    nested_oneofs.append(
+                        descriptor_pb2.OneofDescriptorProto(
+                            name=self.get_oneof_name(field_def)
+                        )
+                    )
+
+                # Otherwise, it's a "regular" field, so just recurse on the type
+                else:
+                    log.debug3("Handling non-oneof field: %s", field_name)
+                    nested_result = self._convert(
+                        entry=self.get_field_type(field_def), name=field_name
+                    )
+                    nested_results = [(nested_result, {})]
+
+                # For all nested fields produced by either the onoof logic or
+                # the single-field logic, construct a FieldDescriptor and add it
+                # to the message descriptor.
+                for nested, extra_kwargs in nested_results:
+                    nested_field_kwargs = copy.copy(field_kwargs)
+                    nested_field_kwargs.update(extra_kwargs)
+
+                    # If the result is an int, it's a type value
+                    if isinstance(nested, int):
+                        nested_field_kwargs["type"] = nested
+
+                    # If the result is an enum descriptor ref, it's an external
+                    # enum
+                    elif isinstance(nested, _descriptor.EnumDescriptor):
+                        nested_field_kwargs[
+                            "type"
+                        ] = _descriptor.FieldDescriptor.TYPE_ENUM
+                        nested_field_kwargs["type_name"] = nested.full_name
+
+                    # If the result is a message descriptor ref, it's an
+                    # external message
+                    elif isinstance(nested, _descriptor.Descriptor):
+                        nested_field_kwargs[
+                            "type"
+                        ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
+                        nested_field_kwargs["type_name"] = nested.full_name
+
+                    # If the result is an enum proto, it's a nested enum
+                    elif isinstance(nested, descriptor_pb2.EnumDescriptorProto):
+                        log.debug3("Adding nested enum %s", nested.name)
+                        nested_field_kwargs[
+                            "type"
+                        ] = _descriptor.FieldDescriptor.TYPE_ENUM
+                        nested_field_kwargs["type_name"] = nested.name
+                        nested_enums.append(nested)
+
+                    # If the result is a message proto, it's a nested message
+                    elif isinstance(nested, descriptor_pb2.DescriptorProto):
+                        log.debug3("Adding nested message %s", nested.name)
+                        nested_field_kwargs[
+                            "type"
+                        ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
+                        nested_field_kwargs["type_name"] = nested.name
+                        nested_messages.append(nested)
+
+                        # If the message has map_entry set, we need to indicate that
+                        # it's repeated
+                        if nested.options.map_entry:
+                            nested_field_kwargs[
+                                "label"
+                            ] = _descriptor.FieldDescriptor.LABEL_REPEATED
+
+                            # If the nested map entry itself has nested types or enums,
+                            # they need to be moved up to this message
+                            while nested.nested_type:
+                                nested_type = nested.nested_type.pop()
+                                plain_name = nested_type.name
+                                nested_name = to_upper_camel(
+                                    "_".join([field_name, plain_name])
+                                )
+                                nested_type.MergeFrom(
+                                    descriptor_pb2.DescriptorProto(name=nested_name)
+                                )
+                                for field in nested.field:
+                                    if field.type_name == plain_name:
+                                        field.MergeFrom(
+                                            descriptor_pb2.FieldDescriptorProto(
+                                                type_name=nested_name
+                                            )
+                                        )
+                                nested_messages.append(nested_type)
+                            while nested.enum_type:
+                                nested_enum = nested.enum_type.pop()
+                                plain_name = nested_enum.name
+                                nested_name = to_upper_camel(
+                                    "_".join([field_name, plain_name])
+                                )
+                                nested_enum.MergeFrom(
+                                    descriptor_pb2.EnumDescriptorProto(name=nested_name)
+                                )
+                                for field in nested.field:
+                                    if field.type_name == plain_name:
+                                        field.MergeFrom(
+                                            descriptor_pb2.FieldDescriptorProto(
+                                                type_name=nested_name
+                                            )
+                                        )
+                                nested_enums.append(nested_enum)
+
+                    # Create the field descriptor
+                    field_descriptors.append(
+                        descriptor_pb2.FieldDescriptorProto(**nested_field_kwargs)
+                    )
+
+            # If additional keys/vals allowed, add a 'special' field for this.
+            # This is one place where there's not a good mapping between some
+            # schema types and proto since proto does not allow for arbitrary
+            # mappings _in addition_ to specific keys. Instead, there needs to
+            # be a special Struct field to hold these additional fields.
+            if self.has_additional_fields(entry):
+                if "additionalProperties" in [
+                    field.name for field in field_descriptors
+                ]:
+                    raise ValueError(
+                        "Cannot specify 'additionalProperties' as a field and support arbitrary key/vals"
+                    )
+                field_descriptors.append(
+                    descriptor_pb2.FieldDescriptorProto(
+                        name="additionalProperties",
+                        number=len(field_descriptors) + 1,
+                        type=_descriptor.FieldDescriptor.TYPE_MESSAGE,
+                        label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+                        type_name=struct_pb2.Struct.DESCRIPTOR.full_name,
+                    )
+                )
+                self.imports.add(struct_pb2.Struct.DESCRIPTOR.file.name)
+
+            # Support optional properties as oneofs i.e. optional int32 foo = 1;
+            # becomes interpreted as oneof _foo { int32 foo = 1; }
+            optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
+            for field in field_descriptors:
+                if (
+                    field.name in self.get_optional_field_names(entry)
+                    and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL
+                ):
+                    log.debug3("Making field %s as optional with oneof", field.name)
+                    # OneofDescriptorProto do not contain fields themselves.
+                    # Instead the FieldDescriptorProto must contain the index of
+                    # the oneof inside the DescriptorProto
+                    optional_oneofs.append(
+                        descriptor_pb2.OneofDescriptorProto(name=f"_{field.name}")
+                    )
+                    field.oneof_index = len(nested_oneofs) + len(optional_oneofs) - 1
+
+            # Construct the message descriptor proto with the aggregated fields
+            # and nested enums/messages/oneofs
+            log.debug3(
+                "All field descriptors for [%s]:\n%s", message_name, field_descriptors
+            )
+            descriptor_proto = descriptor_pb2.DescriptorProto(
+                name=message_name,
+                field=field_descriptors,
+                enum_type=nested_enums,
+                nested_type=nested_messages,
+                oneof_decl=nested_oneofs + optional_oneofs,
+            )
+            return descriptor_proto
+
+        # We should never get here!
+        raise ValueError(f"Got unsupported entry type {entry}")

--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -234,15 +234,6 @@ class ConverterBase(Generic[T], abc.ABC):
         message_name = to_upper_camel(name)
         log.debug("Message name: %s", message_name)
 
-        # Handle descriptor references
-        #
-        # Returns: Descriptor
-        descriptor_ref = self.get_descriptor(entry)
-        if descriptor_ref is not None:
-            log.debug2("Handling direct descriptor reference")
-            self._add_descriptor_imports(descriptor_ref)
-            return descriptor_ref
-
         # Handle concrete types
         #
         # Returns: Union[int, _descriptor.Descriptor, _descriptor.EnumDescriptor]

--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -154,7 +154,7 @@ class ConverterBase(Generic[T], abc.ABC):
     ## Enums ##
 
     @abc.abstractmethod
-    def get_enum_vals(self, entry: Any) -> Optional[List[Tuple[str, int]]]:
+    def get_enum_vals(self, entry: Any) -> Optional[Iterable[Tuple[str, int]]]:
         """Get the ordered list of enum name -> number mappings if this entry is
         an enum
 
@@ -232,133 +232,23 @@ class ConverterBase(Generic[T], abc.ABC):
         the common conversion logic for all converters.
         """
 
-        # Common logic for determining the name to use if a name is needed
-        message_name = to_upper_camel(name)
-        log.debug("Message name: %s", message_name)
-
         # Handle concrete types
-        #
-        # Returns: Union[int, _descriptor.Descriptor, _descriptor.EnumDescriptor]
         concrete_type = self.get_concrete_type(entry)
         if concrete_type:
             log.debug2("Handling concrete type: %s", concrete_type)
-            entry_type = self.type_mapping.get(concrete_type, concrete_type)
-            proto_type_descriptor = None
-            descriptor_ref = self.get_descriptor(entry_type)
-            if descriptor_ref is not None:
-                proto_type_descriptor = descriptor_ref
-            else:
-                if concrete_type not in self.type_mapping:
-                    raise ValueError(f"Invalid type specifier: {concrete_type}")
-                proto_type_val = self.type_mapping[concrete_type]
-                proto_type_descriptor = getattr(proto_type_val, "DESCRIPTOR", None)
-                if proto_type_descriptor is None:
-                    if not isinstance(proto_type_val, int):
-                        raise ValueError(
-                            "All proto_type_map values must be Descriptors or int"
-                        )
-                    proto_type_descriptor = proto_type_val
-
-            # If this is a non-primitive type, make sure any import files are added
-            if isinstance(proto_type_descriptor, _DescriptorTypes):
-                self._add_descriptor_imports(proto_type_descriptor)
-            log.debug3("Returning type %s", proto_type_descriptor)
-            return proto_type_descriptor
+            return self._convert_concrete_type(concrete_type)
 
         # Handle Dicts
-        #
-        # If this is a Dict, handle it by making the "special"
-        # submessage and then making this field's type be that
-        # submessage
-        #
-        # Maps in descriptors are implemented in a _funky_ way. The map
-        # syntax
-        #     map<KeyType, ValType> the_map = 1;
-        #
-        # gets converted to a repeated message as follows:
-        #     option map_entry = true;
-        #     optional KeyType key = 1;
-        #     optional ValType value = 2;
-        #
-        # CITE: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L7512
-        #
-        # Returns: descriptor_pb2.DescriptorProto
-        ##
         map_info = self.get_map_key_val_types(entry)
         if map_info:
             log.debug2("Handling map type: %s", entry)
-            key_type, val_type = map_info
-            nested_cls_name = f"{to_upper_camel(name)}Entry"
-            log.debug3("Making nested map<> class: %s", nested_cls_name)
-            key_field = descriptor_pb2.FieldDescriptorProto(
-                name="key",
-                type=key_type,
-                number=1,
-            )
-            val_field_kwargs = {}
-            msg_descriptor_kwargs = {}
-            if isinstance(val_type, int):
-                val_field_kwargs = {"type": val_type}
-            elif isinstance(val_type, _descriptor.EnumDescriptor):
-                val_field_kwargs = {
-                    "type": _descriptor.FieldDescriptor.TYPE_ENUM,
-                    "type_name": val_type.name,
-                }
-            elif isinstance(val_type, _descriptor.Descriptor):
-                val_field_kwargs = {
-                    "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
-                    "type_name": val_type.name,
-                }
-            elif isinstance(val_type, descriptor_pb2.EnumDescriptorProto):
-                val_field_kwargs = {
-                    "type": _descriptor.FieldDescriptor.TYPE_ENUM,
-                    "type_name": val_type.name,
-                }
-                msg_descriptor_kwargs["enum_type"] = [val_type]
-            elif isinstance(val_type, descriptor_pb2.DescriptorProto):
-                val_field_kwargs = {
-                    "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
-                    "type_name": val_type.name,
-                }
-                msg_descriptor_kwargs["nested_type"] = [val_type]
-            assert (
-                val_field_kwargs
-            ), f"Programming Error: Got unhandled map value type: {val_type}"
-            val_field = descriptor_pb2.FieldDescriptorProto(
-                name="value",
-                number=2,
-                **val_field_kwargs,
-            )
-            nested = descriptor_pb2.DescriptorProto(
-                name=nested_cls_name,
-                field=[key_field, val_field],
-                options=descriptor_pb2.MessageOptions(map_entry=True),
-                **msg_descriptor_kwargs,
-            )
-            return nested
+            return self._convert_map(name, *map_info)
 
         # Handle enums
-        #
-        # Returns: descriptor_pb2.EnumDescriptorProto
         enum_entries = self.get_enum_vals(entry)
         if enum_entries is not None:
             log.debug2("Handling Enum: %s", entry)
-            has_aliases = len(set([entry[1] for entry in enum_entries])) != len(
-                enum_entries
-            )
-            options = descriptor_pb2.EnumOptions(allow_alias=has_aliases)
-            enum_proto = descriptor_pb2.EnumDescriptorProto(
-                name=message_name,
-                value=[
-                    descriptor_pb2.EnumValueDescriptorProto(
-                        name=entry[0],
-                        number=entry[1],
-                    )
-                    for entry in enum_entries
-                ],
-                options=options,
-            )
-            return enum_proto
+            return self._convert_enum(name, enum_entries)
 
         # Handle messages
         #
@@ -366,215 +256,340 @@ class ConverterBase(Generic[T], abc.ABC):
         message_fields = self.get_message_fields(entry)
         if message_fields is not None:
             log.debug2("Handling Message")
-            field_descriptors = []
-            nested_enums = []
-            nested_messages = []
-            nested_oneofs = []
-
-            for field_name, field_def in message_fields:
-                field_number = self.get_field_number(len(field_descriptors), field_def)
-                log.debug2(
-                    "Handling field [%s.%s] (%d)",
-                    message_name,
-                    field_name,
-                    field_number,
-                )
-
-                # Get the field's number
-                field_kwargs = {
-                    "name": field_name,
-                    "number": field_number,
-                    "label": _descriptor.FieldDescriptor.LABEL_OPTIONAL,
-                }
-
-                # Check to see if the field is repeated
-                if self.is_repeated_field(field_def):
-                    log.debug3("Handling repeated field %s", field_name)
-                    field_kwargs["label"] = _descriptor.FieldDescriptor.LABEL_REPEATED
-
-                # If the field is a oneof, handle it as such
-                oneof_fields = self.get_oneof_fields(field_def)
-                if oneof_fields:
-                    log.debug2("Handling oneof field %s", field_name)
-                    nested_results = [
-                        (
-                            self._convert(entry=oneof_field_def, name=oneof_field_name),
-                            {
-                                "oneof_index": len(nested_oneofs),
-                                "number": self.get_field_number(
-                                    len(field_descriptors) + oneof_field_idx,
-                                    oneof_field_def,
-                                ),
-                                "name": oneof_field_name.lower(),
-                            },
-                        )
-                        for oneof_field_idx, (
-                            oneof_field_name,
-                            oneof_field_def,
-                        ) in enumerate(oneof_fields)
-                    ]
-                    # Add the name for this oneof
-                    nested_oneofs.append(
-                        descriptor_pb2.OneofDescriptorProto(
-                            name=self.get_oneof_name(field_def)
-                        )
-                    )
-
-                # Otherwise, it's a "regular" field, so just recurse on the type
-                else:
-                    log.debug3("Handling non-oneof field: %s", field_name)
-                    nested_result = self._convert(
-                        entry=self.get_field_type(field_def), name=field_name
-                    )
-                    nested_results = [(nested_result, {})]
-
-                # For all nested fields produced by either the onoof logic or
-                # the single-field logic, construct a FieldDescriptor and add it
-                # to the message descriptor.
-                for nested, extra_kwargs in nested_results:
-                    nested_field_kwargs = copy.copy(field_kwargs)
-                    nested_field_kwargs.update(extra_kwargs)
-
-                    # If the result is an int, it's a type value
-                    if isinstance(nested, int):
-                        nested_field_kwargs["type"] = nested
-
-                    # If the result is an enum descriptor ref, it's an external
-                    # enum
-                    elif isinstance(nested, _descriptor.EnumDescriptor):
-                        nested_field_kwargs[
-                            "type"
-                        ] = _descriptor.FieldDescriptor.TYPE_ENUM
-                        nested_field_kwargs["type_name"] = nested.full_name
-
-                    # If the result is a message descriptor ref, it's an
-                    # external message
-                    elif isinstance(nested, _descriptor.Descriptor):
-                        nested_field_kwargs[
-                            "type"
-                        ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
-                        nested_field_kwargs["type_name"] = nested.full_name
-
-                    # If the result is an enum proto, it's a nested enum
-                    elif isinstance(nested, descriptor_pb2.EnumDescriptorProto):
-                        log.debug3("Adding nested enum %s", nested.name)
-                        nested_field_kwargs[
-                            "type"
-                        ] = _descriptor.FieldDescriptor.TYPE_ENUM
-                        nested_field_kwargs["type_name"] = nested.name
-                        nested_enums.append(nested)
-
-                    # If the result is a message proto, it's a nested message
-                    elif isinstance(nested, descriptor_pb2.DescriptorProto):
-                        log.debug3("Adding nested message %s", nested.name)
-                        nested_field_kwargs[
-                            "type"
-                        ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
-                        nested_field_kwargs["type_name"] = nested.name
-                        nested_messages.append(nested)
-
-                        # If the message has map_entry set, we need to indicate that
-                        # it's repeated
-                        if nested.options.map_entry:
-                            nested_field_kwargs[
-                                "label"
-                            ] = _descriptor.FieldDescriptor.LABEL_REPEATED
-
-                            # If the nested map entry itself has nested types or enums,
-                            # they need to be moved up to this message
-                            while nested.nested_type:
-                                nested_type = nested.nested_type.pop()
-                                plain_name = nested_type.name
-                                nested_name = to_upper_camel(
-                                    "_".join([field_name, plain_name])
-                                )
-                                nested_type.MergeFrom(
-                                    descriptor_pb2.DescriptorProto(name=nested_name)
-                                )
-                                for field in nested.field:
-                                    if field.type_name == plain_name:
-                                        field.MergeFrom(
-                                            descriptor_pb2.FieldDescriptorProto(
-                                                type_name=nested_name
-                                            )
-                                        )
-                                nested_messages.append(nested_type)
-                            while nested.enum_type:
-                                nested_enum = nested.enum_type.pop()
-                                plain_name = nested_enum.name
-                                nested_name = to_upper_camel(
-                                    "_".join([field_name, plain_name])
-                                )
-                                nested_enum.MergeFrom(
-                                    descriptor_pb2.EnumDescriptorProto(name=nested_name)
-                                )
-                                for field in nested.field:
-                                    if field.type_name == plain_name:
-                                        field.MergeFrom(
-                                            descriptor_pb2.FieldDescriptorProto(
-                                                type_name=nested_name
-                                            )
-                                        )
-                                nested_enums.append(nested_enum)
-
-                    # Create the field descriptor
-                    field_descriptors.append(
-                        descriptor_pb2.FieldDescriptorProto(**nested_field_kwargs)
-                    )
-
-            # If additional keys/vals allowed, add a 'special' field for this.
-            # This is one place where there's not a good mapping between some
-            # schema types and proto since proto does not allow for arbitrary
-            # mappings _in addition_ to specific keys. Instead, there needs to
-            # be a special Struct field to hold these additional fields.
-            if self.has_additional_fields(entry):
-                if "additionalProperties" in [
-                    field.name for field in field_descriptors
-                ]:
-                    raise ValueError(
-                        "Cannot specify 'additionalProperties' as a field and support arbitrary key/vals"
-                    )
-                field_descriptors.append(
-                    descriptor_pb2.FieldDescriptorProto(
-                        name="additionalProperties",
-                        number=len(field_descriptors) + 1,
-                        type=_descriptor.FieldDescriptor.TYPE_MESSAGE,
-                        label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
-                        type_name=struct_pb2.Struct.DESCRIPTOR.full_name,
-                    )
-                )
-                self.imports.add(struct_pb2.Struct.DESCRIPTOR.file.name)
-
-            # Support optional properties as oneofs i.e. optional int32 foo = 1;
-            # becomes interpreted as oneof _foo { int32 foo = 1; }
-            optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
-            for field in field_descriptors:
-                if (
-                    field.name in self.get_optional_field_names(entry)
-                    and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL
-                ):
-                    log.debug3("Making field %s as optional with oneof", field.name)
-                    # OneofDescriptorProto do not contain fields themselves.
-                    # Instead the FieldDescriptorProto must contain the index of
-                    # the oneof inside the DescriptorProto
-                    optional_oneofs.append(
-                        descriptor_pb2.OneofDescriptorProto(name=f"_{field.name}")
-                    )
-                    field.oneof_index = len(nested_oneofs) + len(optional_oneofs) - 1
-
-            # Construct the message descriptor proto with the aggregated fields
-            # and nested enums/messages/oneofs
-            log.debug3(
-                "All field descriptors for [%s]:\n%s", message_name, field_descriptors
-            )
-            descriptor_proto = descriptor_pb2.DescriptorProto(
-                name=message_name,
-                field=field_descriptors,
-                enum_type=nested_enums,
-                nested_type=nested_messages,
-                oneof_decl=nested_oneofs + optional_oneofs,
-            )
-            return descriptor_proto
+            return self._convert_message(name, entry, message_fields)
 
         # We should never get here!
         raise ValueError(f"Got unsupported entry type {entry}")
+
+    def _convert_concrete_type(
+        self, concrete_type: Any
+    ) -> Union[int, _descriptor.Descriptor, _descriptor.EnumDescriptor]:
+        """Perform the common conversion for an extracted concrete type"""
+        entry_type = self.type_mapping.get(concrete_type, concrete_type)
+        proto_type_descriptor = None
+        descriptor_ref = self.get_descriptor(entry_type)
+        if descriptor_ref is not None:
+            proto_type_descriptor = descriptor_ref
+        else:
+            if concrete_type not in self.type_mapping:
+                raise ValueError(f"Invalid type specifier: {concrete_type}")
+            proto_type_val = self.type_mapping[concrete_type]
+            proto_type_descriptor = getattr(proto_type_val, "DESCRIPTOR", None)
+            if proto_type_descriptor is None:
+                if not isinstance(proto_type_val, int):
+                    raise ValueError(
+                        "All proto_type_map values must be Descriptors or int"
+                    )
+                proto_type_descriptor = proto_type_val
+
+        # If this is a non-primitive type, make sure any import files are added
+        if isinstance(proto_type_descriptor, _DescriptorTypes):
+            self._add_descriptor_imports(proto_type_descriptor)
+        log.debug3("Returning type %s", proto_type_descriptor)
+        return proto_type_descriptor
+
+    def _convert_map(
+        self,
+        name: str,
+        key_type: int,
+        val_type: ConvertOutputTypes,
+    ) -> descriptor_pb2.DescriptorProto:
+        """Handle map conversion
+
+        If this is a Dict, handle it by making the "special" submessage and then
+        making this field's type be that submessage
+
+        Maps in descriptors are implemented in a _funky_ way. The map syntax
+            map<KeyType, ValType> the_map = 1;
+
+        gets converted to a repeated message as follows:
+            option map_entry = true;
+            optional KeyType key = 1;
+            optional ValType value = 2;
+
+         CITE: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L7512
+        """
+        nested_cls_name = f"{to_upper_camel(name)}Entry"
+        log.debug3("Making nested map<> class: %s", nested_cls_name)
+        key_field = descriptor_pb2.FieldDescriptorProto(
+            name="key",
+            type=key_type,
+            number=1,
+        )
+        val_field_kwargs = {}
+        msg_descriptor_kwargs = {}
+        if isinstance(val_type, int):
+            val_field_kwargs = {"type": val_type}
+        elif isinstance(val_type, _descriptor.EnumDescriptor):
+            val_field_kwargs = {
+                "type": _descriptor.FieldDescriptor.TYPE_ENUM,
+                "type_name": val_type.name,
+            }
+        elif isinstance(val_type, _descriptor.Descriptor):
+            val_field_kwargs = {
+                "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
+                "type_name": val_type.name,
+            }
+        elif isinstance(val_type, descriptor_pb2.EnumDescriptorProto):
+            val_field_kwargs = {
+                "type": _descriptor.FieldDescriptor.TYPE_ENUM,
+                "type_name": val_type.name,
+            }
+            msg_descriptor_kwargs["enum_type"] = [val_type]
+        elif isinstance(val_type, descriptor_pb2.DescriptorProto):
+            val_field_kwargs = {
+                "type": _descriptor.FieldDescriptor.TYPE_MESSAGE,
+                "type_name": val_type.name,
+            }
+            msg_descriptor_kwargs["nested_type"] = [val_type]
+        assert (
+            val_field_kwargs
+        ), f"Programming Error: Got unhandled map value type: {val_type}"
+        val_field = descriptor_pb2.FieldDescriptorProto(
+            name="value",
+            number=2,
+            **val_field_kwargs,
+        )
+        nested = descriptor_pb2.DescriptorProto(
+            name=nested_cls_name,
+            field=[key_field, val_field],
+            options=descriptor_pb2.MessageOptions(map_entry=True),
+            **msg_descriptor_kwargs,
+        )
+        return nested
+
+    def _convert_enum(
+        self, name: str, enum_entries: Iterable[Tuple[str, int]]
+    ) -> descriptor_pb2.EnumDescriptorProto:
+        """Convert nested enums"""
+        enum_name = to_upper_camel(name)
+        log.debug("Enum name: %s", enum_name)
+        has_aliases = len(set([entry[1] for entry in enum_entries])) != len(
+            enum_entries
+        )
+        options = descriptor_pb2.EnumOptions(allow_alias=has_aliases)
+        enum_proto = descriptor_pb2.EnumDescriptorProto(
+            name=enum_name,
+            value=[
+                descriptor_pb2.EnumValueDescriptorProto(
+                    name=entry[0],
+                    number=entry[1],
+                )
+                for entry in enum_entries
+            ],
+            options=options,
+        )
+        return enum_proto
+
+    def _convert_message(
+        self,
+        name: str,
+        entry: Any,
+        message_fields,
+    ) -> descriptor_pb2.DescriptorProto:
+        """Convert a nested message"""
+        field_descriptors = []
+        nested_enums = []
+        nested_messages = []
+        nested_oneofs = []
+        message_name = to_upper_camel(name)
+        log.debug("Message name: %s", message_name)
+
+        for field_name, field_def in message_fields:
+            field_number = self.get_field_number(len(field_descriptors), field_def)
+            log.debug2(
+                "Handling field [%s.%s] (%d)",
+                message_name,
+                field_name,
+                field_number,
+            )
+
+            # Get the field's number
+            field_kwargs = {
+                "name": field_name,
+                "number": field_number,
+                "label": _descriptor.FieldDescriptor.LABEL_OPTIONAL,
+            }
+
+            # Check to see if the field is repeated
+            if self.is_repeated_field(field_def):
+                log.debug3("Handling repeated field %s", field_name)
+                field_kwargs["label"] = _descriptor.FieldDescriptor.LABEL_REPEATED
+
+            # If the field is a oneof, handle it as such
+            oneof_fields = self.get_oneof_fields(field_def)
+            if oneof_fields:
+                log.debug2("Handling oneof field %s", field_name)
+                nested_results = [
+                    (
+                        self._convert(entry=oneof_field_def, name=oneof_field_name),
+                        {
+                            "oneof_index": len(nested_oneofs),
+                            "number": self.get_field_number(
+                                len(field_descriptors) + oneof_field_idx,
+                                oneof_field_def,
+                            ),
+                            "name": oneof_field_name.lower(),
+                        },
+                    )
+                    for oneof_field_idx, (
+                        oneof_field_name,
+                        oneof_field_def,
+                    ) in enumerate(oneof_fields)
+                ]
+                # Add the name for this oneof
+                nested_oneofs.append(
+                    descriptor_pb2.OneofDescriptorProto(
+                        name=self.get_oneof_name(field_def)
+                    )
+                )
+
+            # Otherwise, it's a "regular" field, so just recurse on the type
+            else:
+                log.debug3("Handling non-oneof field: %s", field_name)
+                nested_result = self._convert(
+                    entry=self.get_field_type(field_def), name=field_name
+                )
+                nested_results = [(nested_result, {})]
+
+            # For all nested fields produced by either the onoof logic or
+            # the single-field logic, construct a FieldDescriptor and add it
+            # to the message descriptor.
+            for nested, extra_kwargs in nested_results:
+                nested_field_kwargs = copy.copy(field_kwargs)
+                nested_field_kwargs.update(extra_kwargs)
+
+                # If the result is an int, it's a type value
+                if isinstance(nested, int):
+                    nested_field_kwargs["type"] = nested
+
+                # If the result is an enum descriptor ref, it's an external
+                # enum
+                elif isinstance(nested, _descriptor.EnumDescriptor):
+                    nested_field_kwargs["type"] = _descriptor.FieldDescriptor.TYPE_ENUM
+                    nested_field_kwargs["type_name"] = nested.full_name
+
+                # If the result is a message descriptor ref, it's an
+                # external message
+                elif isinstance(nested, _descriptor.Descriptor):
+                    nested_field_kwargs[
+                        "type"
+                    ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
+                    nested_field_kwargs["type_name"] = nested.full_name
+
+                # If the result is an enum proto, it's a nested enum
+                elif isinstance(nested, descriptor_pb2.EnumDescriptorProto):
+                    log.debug3("Adding nested enum %s", nested.name)
+                    nested_field_kwargs["type"] = _descriptor.FieldDescriptor.TYPE_ENUM
+                    nested_field_kwargs["type_name"] = nested.name
+                    nested_enums.append(nested)
+
+                # If the result is a message proto, it's a nested message
+                elif isinstance(nested, descriptor_pb2.DescriptorProto):
+                    log.debug3("Adding nested message %s", nested.name)
+                    nested_field_kwargs[
+                        "type"
+                    ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
+                    nested_field_kwargs["type_name"] = nested.name
+                    nested_messages.append(nested)
+
+                    # If the message has map_entry set, we need to indicate that
+                    # it's repeated
+                    if nested.options.map_entry:
+                        nested_field_kwargs[
+                            "label"
+                        ] = _descriptor.FieldDescriptor.LABEL_REPEATED
+
+                        # If the nested map entry itself has nested types or enums,
+                        # they need to be moved up to this message
+                        while nested.nested_type:
+                            nested_type = nested.nested_type.pop()
+                            plain_name = nested_type.name
+                            nested_name = to_upper_camel(
+                                "_".join([field_name, plain_name])
+                            )
+                            nested_type.MergeFrom(
+                                descriptor_pb2.DescriptorProto(name=nested_name)
+                            )
+                            for field in nested.field:
+                                if field.type_name == plain_name:
+                                    field.MergeFrom(
+                                        descriptor_pb2.FieldDescriptorProto(
+                                            type_name=nested_name
+                                        )
+                                    )
+                            nested_messages.append(nested_type)
+                        while nested.enum_type:
+                            nested_enum = nested.enum_type.pop()
+                            plain_name = nested_enum.name
+                            nested_name = to_upper_camel(
+                                "_".join([field_name, plain_name])
+                            )
+                            nested_enum.MergeFrom(
+                                descriptor_pb2.EnumDescriptorProto(name=nested_name)
+                            )
+                            for field in nested.field:
+                                if field.type_name == plain_name:
+                                    field.MergeFrom(
+                                        descriptor_pb2.FieldDescriptorProto(
+                                            type_name=nested_name
+                                        )
+                                    )
+                            nested_enums.append(nested_enum)
+
+                # Create the field descriptor
+                field_descriptors.append(
+                    descriptor_pb2.FieldDescriptorProto(**nested_field_kwargs)
+                )
+
+        # If additional keys/vals allowed, add a 'special' field for this.
+        # This is one place where there's not a good mapping between some
+        # schema types and proto since proto does not allow for arbitrary
+        # mappings _in addition_ to specific keys. Instead, there needs to
+        # be a special Struct field to hold these additional fields.
+        if self.has_additional_fields(entry):
+            if "additionalProperties" in [field.name for field in field_descriptors]:
+                raise ValueError(
+                    "Cannot specify 'additionalProperties' as a field and support arbitrary key/vals"
+                )
+            field_descriptors.append(
+                descriptor_pb2.FieldDescriptorProto(
+                    name="additionalProperties",
+                    number=len(field_descriptors) + 1,
+                    type=_descriptor.FieldDescriptor.TYPE_MESSAGE,
+                    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
+                    type_name=struct_pb2.Struct.DESCRIPTOR.full_name,
+                )
+            )
+            self.imports.add(struct_pb2.Struct.DESCRIPTOR.file.name)
+
+        # Support optional properties as oneofs i.e. optional int32 foo = 1;
+        # becomes interpreted as oneof _foo { int32 foo = 1; }
+        optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
+        for field in field_descriptors:
+            if (
+                field.name in self.get_optional_field_names(entry)
+                and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL
+            ):
+                log.debug3("Making field %s as optional with oneof", field.name)
+                # OneofDescriptorProto do not contain fields themselves.
+                # Instead the FieldDescriptorProto must contain the index of
+                # the oneof inside the DescriptorProto
+                optional_oneofs.append(
+                    descriptor_pb2.OneofDescriptorProto(name=f"_{field.name}")
+                )
+                field.oneof_index = len(nested_oneofs) + len(optional_oneofs) - 1
+
+        # Construct the message descriptor proto with the aggregated fields
+        # and nested enums/messages/oneofs
+        log.debug3(
+            "All field descriptors for [%s]:\n%s", message_name, field_descriptors
+        )
+        descriptor_proto = descriptor_pb2.DescriptorProto(
+            name=message_name,
+            field=field_descriptors,
+            enum_type=nested_enums,
+            nested_type=nested_messages,
+            oneof_decl=nested_oneofs + optional_oneofs,
+        )
+        return descriptor_proto

--- a/jtd_to_proto/converter_base.py
+++ b/jtd_to_proto/converter_base.py
@@ -36,6 +36,21 @@ _DescriptorTypesUnion = Union[_descriptor.Descriptor, _descriptor.EnumDescriptor
 class ConverterBase(Generic[T], abc.ABC):
     __doc__ = __doc__
 
+    # Types that can be returned from _convert. This is exposed as public so
+    # that derived converters can reference it
+    ConvertOutputTypes = Union[
+        # Concrete type
+        int,
+        # Message descriptor reference
+        _descriptor.Descriptor,
+        # Enum descriptor reference
+        _descriptor.EnumDescriptor,
+        # Nested message
+        descriptor_pb2.DescriptorProto,
+        # Nested enum
+        descriptor_pb2.EnumDescriptorProto,
+    ]
+
     def __init__(
         self,
         name: str,
@@ -133,7 +148,7 @@ class ConverterBase(Generic[T], abc.ABC):
     def get_map_key_val_types(
         self,
         entry: Any,
-    ) -> Optional[Tuple[int, Union[int, _descriptor.Descriptor]]]:
+    ) -> Optional[Tuple[int, ConvertOutputTypes]]:
         """Get the key and value types for a given map type"""
 
     ## Enums ##
@@ -212,20 +227,7 @@ class ConverterBase(Generic[T], abc.ABC):
         log.debug3("Adding import file %s", import_file)
         self.imports.add(import_file)
 
-    def _convert(
-        self, entry: Any, name: str
-    ) -> Union[
-        # Nested message
-        descriptor_pb2.DescriptorProto,
-        # Nested enum
-        descriptor_pb2.EnumDescriptorProto,
-        # Concrete primitive type enum value
-        int,
-        # Concrete message type reference
-        _descriptor.Descriptor,
-        # Concrete enum type reference
-        _descriptor.EnumDescriptor,
-    ]:
+    def _convert(self, entry: Any, name: str) -> ConvertOutputTypes:
         """This is the core recursive implementation detail function that does
         the common conversion logic for all converters.
         """

--- a/jtd_to_proto/json_to_service.py
+++ b/jtd_to_proto/json_to_service.py
@@ -21,7 +21,7 @@ from .descriptor_to_message_class import (
     _add_protobuf_serializers,
     descriptor_to_message_class,
 )
-from .jtd_to_proto import _safe_add_fd_to_pool
+from .utils import safe_add_fd_to_pool
 from .validation import JTD_TYPE_VALIDATORS, validate_jtd
 
 log = alog.use_channel("JSON2S")
@@ -128,7 +128,7 @@ def json_to_service(
 
     # Add the FileDescriptorProto to the Descriptor Pool
     log.debug("Adding Descriptors to DescriptorPool")
-    _safe_add_fd_to_pool(fd_proto, descriptor_pool)
+    safe_add_fd_to_pool(fd_proto, descriptor_pool)
 
     # Return the descriptor for the top-level message
     fullname = name if not package else ".".join([package, name])

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -9,299 +9,15 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import struct_pb2, timestamp_pb2
-import google.protobuf.descriptor_pool
 
 # First Party
 import alog
 
 # Local
+from .utils import safe_add_fd_to_pool, to_upper_camel
 from .validation import is_valid_jtd
 
 log = alog.use_channel("JTD2P")
-
-
-## Utils #######################################################################
-
-
-def _to_upper_camel(snake_str: str) -> str:
-    """Convert a snake_case string to UpperCamelCase"""
-    if not snake_str:
-        return snake_str
-    return (
-        snake_str[0].upper()
-        + re.sub("_([a-zA-Z])", lambda pat: pat.group(1).upper(), snake_str)[1:]
-    )
-
-
-def _safe_add_fd_to_pool(
-    fd_proto: descriptor_pb2.FileDescriptorProto,
-    descriptor_pool: google.protobuf.descriptor_pool.DescriptorPool,
-):
-    try:
-        existing_fd = descriptor_pool.FindFileByName(fd_proto.name)
-        # Rebuild the file descriptor proto so that we can compare; there is
-        # almost certainly a more efficient way to compare that avoids this.
-        existing_proto = descriptor_pb2.FileDescriptorProto()
-        existing_fd.CopyToProto(existing_proto)
-        # Raise if the file exists already with different content
-        # Otherwise, do not attempt to re-add the file
-        if not _are_same_file_descriptors(fd_proto, existing_proto):
-            # NOTE: This is a TypeError because that is what you get most of the time when you
-            # have conflict issues in the descriptor pool arising from JTD to Proto followed by
-            # importing differing defs for the same top level message type using different file
-            # names (i.e., skipping this validation) compiled by protoc. Raising TypeError here
-            # ensures that we at least usually raise the same error type regardless of
-            # import / operation order.
-            raise TypeError(
-                f"Cannot add new file {fd_proto.name} to descriptor pool, file already exists with different content"
-            )
-    except KeyError:
-        # It's okay for the file to not already exist, we'll add it!
-        try:
-            descriptor_pool.Add(fd_proto)
-        except TypeError as e:
-            # More likely than not, this is a duplicate symbol; the main case in which
-            # this could occur is when you've compiled files with protoc, added them to your
-            # descriptor pool, and ALSO added the defs in your jtd_to_proto schema, but the
-            # lookup validation with fd_proto.name is skipped because the .proto file fed to
-            # protoc had a different name!
-            raise TypeError(
-                f"Failed to add {fd_proto.name} to descriptor pool with error: [{e}]; Hint: if you previously used protoc to compile this definition, you must recompile it with the name {fd_proto.name} to avoid the conflict."
-            )
-
-
-def _are_same_file_descriptors(
-    d1: descriptor_pb2.FileDescriptorProto, d2: descriptor_pb2.FileDescriptorProto
-) -> bool:
-    """Validate that there are no consistency issues in the message descriptors of
-    our proto file descriptors.
-
-    Args:
-        d1: descriptor_pb2.FileDescriptorProto
-            First FileDescriptorProto we want to compare.
-        d2: descriptor_pb2.FileDescriptorProto
-            second FileDescriptorProto we want to compare.
-
-    Returns:
-        True if the provided file descriptor proto files are identical.
-    """
-    have_same_deps = d1.dependency == d2.dependency
-    are_same_package = d1.package == d2.package
-    have_aligned_enums = _are_same_enum_descriptor(d1.enum_type, d2.enum_type)
-    have_aligned_messages = _check_message_descs_alignment(
-        d1.message_type, d2.message_type
-    )
-    have_aligned_services = _check_service_desc_alignment(d1.service, d2.service)
-    return (
-        have_same_deps
-        and are_same_package
-        and have_aligned_enums
-        and have_aligned_messages
-        and have_aligned_services
-    )
-
-
-def _are_same_enum_descriptor(d1_enums: Any, d2_enums: Any) -> bool:
-    """Determine if two iterables of EnumDescriptorProtos have the same enums.
-    This means the following:
-
-    1. They have the same names in their respective .enum_type properties.
-    2. For every enum in enum_type, they have the same number of values & the same names.
-
-    Args:
-        d1_enums: Any
-            First iterable of enum desc protos to compare, e.g., RepeatedCompositeContainer.
-        d2_enums: Any
-            Second iterable of enum desc protos to compare, e.g., RepeatedCompositeContainer.
-
-    Returns:
-        True if the provided iterable enum descriptors are identical.
-    """
-    d1_enum_map = {enum.name: enum for enum in d1_enums}
-    d2_enum_map = {enum.name: enum for enum in d2_enums}
-    if d1_enum_map.keys() != d2_enum_map.keys():
-        return False
-
-    for enum_name in d1_enum_map.keys():
-        d1_enum_descriptor = d1_enum_map[enum_name]
-        d2_enum_descriptor = d2_enum_map[enum_name]
-        if len(d1_enum_descriptor.value) != len(d2_enum_descriptor.value):
-            return False
-        # Compare each entry in the repeated composite container,
-        # i.e., all of our EnumValueDescriptorProto objects
-        for first_enum_val, second_enum_val in zip(
-            d1_enum_descriptor.value, d2_enum_descriptor.value
-        ):
-            if (
-                first_enum_val.name != second_enum_val.name
-                or first_enum_val.number != second_enum_val.number
-            ):
-                return False
-    return True
-
-
-def _check_message_descs_alignment(
-    d1_msg_container: Any, d2_msg_container: Any
-) -> bool:
-    """Determine if two message descriptor proto containers, i.e., RepeatedCompositeContainers
-    have the same message types. This means the following:
-
-    1. The messages contained in each FileDescriptorProto are the same.
-    2. For each of those respective messages, their respective fields are roughly the same.
-       Note that this includes nested_types, which are verified recursively.
-
-    Args:
-        d1_msg_container: Any
-            First container iterable of message descriptors protos to be verified.
-        d2_msg_container: Any
-            Second container iterable of message descriptors protos to be verified.
-
-    Returns:
-        bool
-            True if the contained message descriptor protos are identical.
-    """
-    d1_msg_descs = {msg.name: msg for msg in d1_msg_container}
-    d2_msg_descs = {msg.name: msg for msg in d2_msg_container}
-
-    # Ensure that our descriptors have the same dependencies & top level message types
-    if d1_msg_descs.keys() != d2_msg_descs.keys():
-        return False
-    # For every encapsulated message descriptor, ensure that every field has the same
-    # name, number, label, type, and type name
-    for msg_name in d1_msg_descs.keys():
-        d1_message_descriptor = d1_msg_descs[msg_name]
-        d2_message_descriptor = d2_msg_descs[msg_name]
-        # Ensure that these messages are actually the same
-        if not _are_same_message_descriptor(
-            d1_message_descriptor, d2_message_descriptor
-        ):
-            return False
-    return True
-
-
-def _check_service_desc_alignment(
-    d1_service_list: List[descriptor_pb2.ServiceDescriptorProto],
-    d2_service_list: List[descriptor_pb2.ServiceDescriptorProto],
-) -> bool:
-    d1_service_descs = {svc.name: svc for svc in d1_service_list}
-    d2_service_descs = {svc.name: svc for svc in d2_service_list}
-
-    log.debug(
-        "Checking service descriptors: [%s] and [%s]",
-        d1_service_descs,
-        d2_service_descs,
-    )
-    # Ensure that our service names are the same set
-    if d1_service_descs.keys() != d2_service_descs.keys():
-        # Excluding from code coverage: We can't actually generate file descriptors with multiple services in them.
-        # But, this check seems pretty basic and worth leaving in if this ever gets extended in the future.
-        return False  # pragma: no cover
-
-    # For every service, ensure that every method is the same
-    for svc_name in d1_service_descs.keys():
-        d1_service = d1_service_descs[svc_name]
-        d2_service = d2_service_descs[svc_name]
-
-        if not _are_same_service_descriptor(d1_service, d2_service):
-            return False
-    return True
-
-
-def _are_same_service_descriptor(
-    d1_service: descriptor_pb2.ServiceDescriptorProto,
-    d2_service: descriptor_pb2.ServiceDescriptorProto,
-) -> bool:
-    # Not checking service.name because we only compare services with the same name
-
-    d1_methods = {method.name: method for method in d1_service.method}
-    d2_methods = {method.name: method for method in d2_service.method}
-
-    # Ensure that our service names are the same set
-    if d1_methods.keys() != d2_methods.keys():
-        return False
-
-    # For every service, ensure that every method is the same
-    for method_name in d1_methods.keys():
-        d1_method = d1_methods[method_name]
-        d2_method = d2_methods[method_name]
-
-        if not _are_same_method_descriptor(d1_method, d2_method):
-            return False
-
-    return True
-
-
-def _are_same_method_descriptor(
-    d1_method: descriptor_pb2.MethodDescriptorProto,
-    d2_method: descriptor_pb2.MethodDescriptorProto,
-) -> bool:
-    # Not checking method.name because we only compare services with the same name
-
-    if not _are_types_similar(d1_method.input_type, d2_method.input_type):
-        return False
-    if not _are_types_similar(d1_method.output_type, d2_method.output_type):
-        return False
-    # TODO: Add the ability for `json_to_service` to set options + streaming settings.
-    # Then we can test this!
-    if d1_method.options != d2_method.options:
-        log.debug(  # pragma: no cover
-            "Method options differ! [%s] vs. [%s]", d1_method.options, d2_method.options
-        )
-        return False  # pragma: no cover
-    if d1_method.client_streaming != d2_method.client_streaming:
-        return False  # pragma: no cover
-    if d1_method.server_streaming != d2_method.server_streaming:
-        return False  # pragma: no cover
-    return True
-
-
-def _are_types_similar(type_1: str, type_2: str) -> bool:
-    """Returns true iff type names are the same or differ only by a leading `.`"""
-    # TODO: figure out why when you `json_to_service` the same thing twice, on of the service descriptors ends up with
-    # fully qualified names (.foo.bar.Foo) and the other does not (foo.bar.Foo)
-    return type_1.lstrip(".") == type_2.lstrip(".")
-
-
-def _are_same_message_descriptor(
-    d1: descriptor_pb2.DescriptorProto, d2: descriptor_pb2.DescriptorProto
-) -> bool:
-    """Determine if two message descriptors proto are representing the same thing. We do this by
-    ensuring that their fields all have the same fields, then inspecting each of their labels,
-    names, etc, for alignment. We do the same for any nested fields.
-
-    Args:
-        d1: descriptor_pb2.DescriptorProto
-            First message descriptor to be compared.
-        d2: descriptor_pb2.DescriptorProto
-            second message descriptor to be compared.
-
-    Returns:
-        bool
-            True of messages are identical, False otherwise.
-    """
-    # Compare any nested enums in our message.
-    if not _are_same_enum_descriptor(d1.enum_type, d2.enum_type):
-        return False
-    # Make sure all of our named fields align, then check them individually
-    d1_field_descs = {field.name: field for field in d1.field}
-    d2_field_descs = {field.name: field for field in d2.field}
-    if d1_field_descs.keys() != d2_field_descs.keys():
-        return False
-    for field_name in d1_field_descs.keys():
-        # We consider two fields equal if they have the same name, label
-        d1_field_descriptor = d1_field_descs[field_name]
-        d2_field_descriptor = d2_field_descs[field_name]
-        if (
-            d1_field_descriptor.label != d2_field_descriptor.label
-            or d1_field_descriptor.type != d2_field_descriptor.type
-        ):
-            return False
-    # For nested fields, we treat them similarly to how we've treated messages
-    # and recurse into comparisons used for the top level messages.
-    if d1.nested_type or d2.nested_type:
-        return _check_message_descs_alignment(d1.nested_type, d2.nested_type)
-    # Otherwise, we have no more nested layers to check; we're done!
-    return True
 
 
 ## Globals #####################################################################
@@ -384,7 +100,6 @@ def jtd_to_proto(
     descriptor_proto = _jtd_to_proto_impl(
         jtd_def=jtd_def,
         name=name,
-        package=package,
         imports=imports,
     )
     proto_kwargs = {}
@@ -414,7 +129,7 @@ def jtd_to_proto(
         log.debug2("Using default descriptor pool")
         descriptor_pool = _descriptor_pool.Default()
 
-    _safe_add_fd_to_pool(fd_proto, descriptor_pool)
+    safe_add_fd_to_pool(fd_proto, descriptor_pool)
 
     # Return the descriptor for the top-level message
     fullname = name if not package else ".".join([package, name])
@@ -430,7 +145,6 @@ def _jtd_to_proto_impl(
     *,
     jtd_def: Dict[str, Union[dict, str]],
     name: Optional[str],
-    package: str,
     imports: List[str],
 ) -> Union[
     descriptor_pb2.DescriptorProto,
@@ -443,7 +157,7 @@ def _jtd_to_proto_impl(
     """
 
     # Common logic for determining the name to use if a name is needed
-    message_name = _to_upper_camel(name)
+    message_name = to_upper_camel(name)
     log.debug("Message name: %s", message_name)
 
     # If the jtd definition is a single "type": "name", perform the base-case
@@ -532,7 +246,6 @@ def _jtd_to_proto_impl(
         nested = _jtd_to_proto_impl(
             jtd_def=entry_msg_type,
             name=entry_msg_name,
-            package=package,
             imports=imports,
         )
 
@@ -596,7 +309,6 @@ def _jtd_to_proto_impl(
                             _jtd_to_proto_impl(
                                 jtd_def=mapping_def,
                                 name=mapping_name,
-                                package=package,
                                 imports=imports,
                             ),
                             {
@@ -619,7 +331,6 @@ def _jtd_to_proto_impl(
                         _jtd_to_proto_impl(
                             jtd_def=field_type_def,
                             name=field_name,
-                            package=package,
                             imports=imports,
                         ),
                         {},
@@ -667,7 +378,7 @@ def _jtd_to_proto_impl(
                         while nested.nested_type:
                             nested_type = nested.nested_type.pop()
                             plain_name = nested_type.name
-                            nested_name = _to_upper_camel(
+                            nested_name = to_upper_camel(
                                 "_".join([field_name, plain_name])
                             )
                             nested_type.MergeFrom(
@@ -684,7 +395,7 @@ def _jtd_to_proto_impl(
                         while nested.enum_type:
                             nested_enum = nested.enum_type.pop()
                             plain_name = nested_enum.name
-                            nested_name = _to_upper_camel(
+                            nested_name = to_upper_camel(
                                 "_".join([field_name, plain_name])
                             )
                             nested_enum.MergeFrom(

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -1,20 +1,17 @@
 # Standard
-from typing import Any, Dict, List, Optional, Tuple, Union
-import copy
-import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 # Third Party
 from google.protobuf import any_pb2
 from google.protobuf import descriptor as _descriptor
-from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool as _descriptor_pool
-from google.protobuf import struct_pb2, timestamp_pb2
+from google.protobuf import timestamp_pb2
 
 # First Party
 import alog
 
 # Local
-from .utils import safe_add_fd_to_pool, to_upper_camel
+from .converter_base import ConverterBase
 from .validation import is_valid_jtd
 
 log = alog.use_channel("JTD2P")
@@ -46,6 +43,9 @@ JTD_TO_PROTO_TYPES = {
     "bytes": _descriptor.FieldDescriptor.TYPE_BYTES,
 }
 
+# Common type used everywhere for a JTD dict
+_JtdDefType = Dict[str, Union[dict, str]]
+
 
 ## Interface ###################################################################
 
@@ -53,10 +53,10 @@ JTD_TO_PROTO_TYPES = {
 def jtd_to_proto(
     name: str,
     package: str,
-    jtd_def: Dict[str, Union[dict, str]],
+    jtd_def: _JtdDefType,
     *,
     validate_jtd: bool = False,
-    valid_types: Optional[List[str]] = None,
+    type_mapping: Optional[Dict[str, Union[int, _descriptor.Descriptor]]] = None,
     descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
 ) -> _descriptor.Descriptor:
     """Convert a JTD schema into a set of proto DESCRIPTOR objects.
@@ -74,6 +74,8 @@ def jtd_to_proto(
     Kwargs:
         validate_jtd:  bool
             Whether or not to validate the JTD schema
+        type_mapping:  Optional[Dict[str, Union[int, _descriptor.Descriptor]]]
+            A non-default mapping from JTD type names to proto types
         descriptor_pool:  Optional[descriptor_pool.DescriptorPool]
             If given, this DescriptorPool will be used to aggregate the set of
             message descriptors
@@ -82,385 +84,146 @@ def jtd_to_proto(
         descriptor:  descriptor.Descriptor
             The top-level MessageDescriptor corresponding to this jtd definition
     """
-    # If performing validation, attempt to parse schema with jtd and throw away
-    # the results
-    if validate_jtd:
-        log.debug2("Validating JTD")
-        valid_types = valid_types or JTD_TO_PROTO_TYPES.keys()
-        if not is_valid_jtd(jtd_def, valid_types=valid_types):
-            raise ValueError(f"Invalid JTD Schema: {jtd_def}")
-
-    # This list will be used to aggregate the list of message DescriptorProtos
-    # for any nested message objects defined inline
-    imports = []
-
-    # Perform the recursive conversion to update the descriptors and enums in
-    # place
-    log.debug("Performing conversion")
-    descriptor_proto = _jtd_to_proto_impl(
-        jtd_def=jtd_def,
+    return JTDConverter(
         name=name,
-        imports=imports,
-    )
-    proto_kwargs = {}
-    is_enum = False
-    if isinstance(descriptor_proto, descriptor_pb2.DescriptorProto):
-        proto_kwargs["message_type"] = [descriptor_proto]
-    elif isinstance(descriptor_proto, descriptor_pb2.EnumDescriptorProto):
-        is_enum = True
-        proto_kwargs["enum_type"] = [descriptor_proto]
-    else:
-        raise ValueError("Only messages and enums are supported")
-
-    # Create the FileDescriptorProto with all messages
-    log.debug("Creating FileDescriptorProto")
-    fd_proto = descriptor_pb2.FileDescriptorProto(
-        name=f"{name.lower()}.proto",
         package=package,
-        syntax="proto3",
-        dependency=sorted(list(set(imports))),
-        **proto_kwargs,
-    )
-    log.debug4("Full FileDescriptorProto:\n%s", fd_proto)
-
-    # Add the FileDescriptorProto to the Descriptor Pool
-    log.debug("Adding Descriptors to DescriptorPool")
-    if descriptor_pool is None:
-        log.debug2("Using default descriptor pool")
-        descriptor_pool = _descriptor_pool.Default()
-
-    safe_add_fd_to_pool(fd_proto, descriptor_pool)
-
-    # Return the descriptor for the top-level message
-    fullname = name if not package else ".".join([package, name])
-    if is_enum:
-        return descriptor_pool.FindEnumTypeByName(fullname)
-    return descriptor_pool.FindMessageTypeByName(fullname)
+        jtd_def=jtd_def,
+        validate=validate_jtd,
+        type_mapping=type_mapping,
+        descriptor_pool=descriptor_pool,
+    ).descriptor
 
 
 ## Impl ########################################################################
 
 
-def _jtd_to_proto_impl(
-    *,
-    jtd_def: Dict[str, Union[dict, str]],
-    name: Optional[str],
-    imports: List[str],
-) -> Union[
-    descriptor_pb2.DescriptorProto,
-    descriptor_pb2.EnumDescriptorProto,
-    int,
-    Tuple[str, int],
-]:
-    """Recursive implementation of converting messages, fields, enums, arrays,
-    and maps from JTD to their respective *DescriptorProto representations.
-    """
+class JTDConverter(ConverterBase):
+    """Converter implementation for JTD source schemas"""
 
-    # Common logic for determining the name to use if a name is needed
-    message_name = to_upper_camel(name)
-    log.debug("Message name: %s", message_name)
-
-    # If the jtd definition is a single "type": "name", perform the base-case
-    # and look up the proto type
-    type_name = jtd_def.get("type")
-    if type_name is not None:
-        # If the type name is itself a descriptor, use it as the value directly
-        proto_type_descriptor = None
-        is_enum = False
-        if isinstance(type_name, _descriptor.Descriptor):
-            proto_type_descriptor = type_name
-        elif isinstance(type_name, _descriptor.EnumDescriptor):
-            is_enum = True
-            proto_type_descriptor = type_name
-        else:
-            proto_type_val = JTD_TO_PROTO_TYPES.get(type_name)
-            proto_type_descriptor = getattr(proto_type_val, "DESCRIPTOR", None)
-            if proto_type_val is None:
-                raise ValueError(f"No proto mapping for type '{type_name}'")
-            elif proto_type_descriptor is None:
-                assert isinstance(
-                    proto_type_val, int
-                ), f"PROGRAMMING ERROR: Bad proto value type for {type_name}"
-                return proto_type_val
-
-        assert (
-            proto_type_descriptor is not None
-        ), "PROGRAMMING ERROR: proto_type_descriptor not defined"
-        type_name = proto_type_descriptor.full_name
-        import_file = proto_type_descriptor.file.name
-        log.debug3(
-            "Adding import file %s for known nested type %s",
-            import_file,
-            type_name,
-        )
-        imports.append(import_file)
-        return (
-            type_name,
-            (
-                _descriptor.FieldDescriptor.TYPE_ENUM
-                if is_enum
-                else _descriptor.FieldDescriptor.TYPE_MESSAGE
-            ),
+    def __init__(
+        self,
+        name: str,
+        package: str,
+        jtd_def: _JtdDefType,
+        *,
+        type_mapping: Optional[Dict[str, Union[int, _descriptor.Descriptor]]] = None,
+        validate: bool = False,
+        descriptor_pool: Optional[_descriptor_pool.DescriptorPool] = None,
+    ):
+        """Fill in the default type mapping and additional default vals, then
+        initialize the parent
+        """
+        type_mapping = type_mapping or JTD_TO_PROTO_TYPES
+        super().__init__(
+            name=name,
+            package=package,
+            source_schema=jtd_def,
+            type_mapping=type_mapping,
+            validate=validate,
+            descriptor_pool=descriptor_pool,
         )
 
-    # If the definition has "enum" it's an enum
-    enum = jtd_def.get("enum")
-    if enum is not None:
-        enum_proto = descriptor_pb2.EnumDescriptorProto(
-            name=message_name,
-            value=[
-                descriptor_pb2.EnumValueDescriptorProto(
-                    name=entry_name,
-                    number=i,
-                )
-                for i, entry_name in enumerate(enum)
-            ],
-        )
-        return enum_proto
+    ## Abstract Interface ######################################################
 
-    # If the definition has "values" it's a map
-    #
-    # Maps in descriptors are implemented in a _funky_ way. The map syntax=
-    #     map<KeyType, ValType> the_map = 1;
-    #
-    # gets converted to a repeated message as follows:
-    #     option map_entry = true;
-    #     optional KeyType key = 1;
-    #     optional ValType value = 2;
-    #
-    # CITE: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.cc#L7102
-    ##
-    values = jtd_def.get("values")
-    if values is not None:
-        # Construct the JTD representation of the message
-        entry_msg_type = {
-            "properties": {
-                "key": {"type": "string"},
-                "value": values,
-            }
-        }
-        entry_msg_name = "{}Entry".format(message_name)
-        log.debug3("Map entry message for %s: %s", message_name, entry_msg_name)
+    def validate(self, source_schema: _JtdDefType) -> bool:
+        """Perform preprocess validation of the input"""
+        log.debug2("Validating JTD")
+        valid_types = self.type_mapping.keys()
+        return is_valid_jtd(source_schema, valid_types=valid_types)
 
-        # Perform the recursive conversion
-        nested = _jtd_to_proto_impl(
-            jtd_def=entry_msg_type,
-            name=entry_msg_name,
-            imports=imports,
-        )
+    ## Types ##
 
-        # Set the map_entry option
-        nested.MergeFrom(
-            descriptor_pb2.DescriptorProto(
-                options=descriptor_pb2.MessageOptions(map_entry=True)
-            )
-        )
-        return nested
+    def get_concrete_type(self, entry: _JtdDefType) -> Any:
+        """If this is a concrete type, get the JTD key for it"""
+        return entry.get("type")
 
-    # If the object has "properties", it's a message
-    properties = jtd_def.get("properties", {})
-    optional_properties = jtd_def.get("optionalProperties", {})
-    all_properties = dict(**properties, **optional_properties)
-    additional_properties = jtd_def.get("additionalProperties")
-    if all_properties or additional_properties:
-        field_descriptors: List[descriptor_pb2.FieldDescriptorProto] = []
-        nested_enums: List[descriptor_pb2.EnumDescriptorProto] = []
-        nested_messages: List[descriptor_pb2.DescriptorProto] = []
-        nested_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
+    ## Maps ##
 
-        # Iterate each field and perform the recursive conversion
-        for field_index, (field_name, field_def) in enumerate(all_properties.items()):
-            log.debug2(
-                "Handling property [%s.%s] (%d)", message_name, field_name, field_index
-            )
-            log.debug3("%s", field_def)
-
-            field_kwargs = {
-                "name": field_name,
-                "number": len(field_descriptors) + 1,
-                "label": _descriptor.FieldDescriptor.LABEL_OPTIONAL,
-            }
-            field_type_def = field_def
-
-            # If the definition is nested with "elements" it's a repeated field
-            elements = field_def.get("elements")
-            if elements is not None:
-                field_kwargs["label"] = _descriptor.FieldDescriptor.LABEL_REPEATED
-                field_type_def = elements
-
-            # If the definition is a "discriminator" it's a oneof. This means
-            # we need to recurse on all elements of the "mapping" and perform
-            # the nested type logic for each result, then add the special
-            # oneof field
-            discriminator = field_def.get("discriminator")
-            nested_results = []
-            if discriminator is not None:
-                mapping = field_def.get("mapping")
-                assert isinstance(
-                    mapping, dict
-                ), "Invalid discriminator without mapping"
-
-                # Make all the sub-fields within the oneof
-                for mapping_idx, (mapping_name, mapping_def) in enumerate(
-                    mapping.items()
-                ):
-                    nested_results.append(
-                        (
-                            _jtd_to_proto_impl(
-                                jtd_def=mapping_def,
-                                name=mapping_name,
-                                imports=imports,
-                            ),
-                            {
-                                "oneof_index": len(nested_oneofs),
-                                "number": field_kwargs["number"] + mapping_idx,
-                                "name": mapping_name.lower(),
-                            },
-                        )
-                    )
-
-                # Add the name for this oneof
-                nested_oneofs.append(
-                    descriptor_pb2.OneofDescriptorProto(name=discriminator)
-                )
-
-            # If not a oneof, just recurse once
-            else:
-                nested_results = [
-                    (
-                        _jtd_to_proto_impl(
-                            jtd_def=field_type_def,
-                            name=field_name,
-                            imports=imports,
-                        ),
-                        {},
-                    )
-                ]
-
-            for nested, extra_kwargs in nested_results:
-                nested_field_kwargs = copy.copy(field_kwargs)
-                nested_field_kwargs.update(extra_kwargs)
-
-                # If the result is an int, it's a type value
-                if isinstance(nested, int):
-                    nested_field_kwargs["type"] = nested
-
-                # If the result is a tuple, it's an imported message or name
-                elif isinstance(nested, tuple):
-                    (
-                        nested_field_kwargs["type_name"],
-                        nested_field_kwargs["type"],
-                    ) = nested
-
-                # If the result is an enum, add it as a nested enum
-                elif isinstance(nested, descriptor_pb2.EnumDescriptorProto):
-                    nested_field_kwargs["type"] = _descriptor.FieldDescriptor.TYPE_ENUM
-                    nested_field_kwargs["type_name"] = nested.name
-                    nested_enums.append(nested)
-
-                # If the result is a message, add it as a nested message
-                elif isinstance(nested, descriptor_pb2.DescriptorProto):
-                    nested_field_kwargs[
-                        "type"
-                    ] = _descriptor.FieldDescriptor.TYPE_MESSAGE
-                    nested_field_kwargs["type_name"] = nested.name
-                    nested_messages.append(nested)
-
-                    # If the message has map_entry set, we need to indicate that
-                    # it's repeated
-                    if nested.options.map_entry:
-                        nested_field_kwargs[
-                            "label"
-                        ] = _descriptor.FieldDescriptor.LABEL_REPEATED
-
-                        # If the nested map entry itself has nested types or enums,
-                        # they need to be moved up to this message
-                        while nested.nested_type:
-                            nested_type = nested.nested_type.pop()
-                            plain_name = nested_type.name
-                            nested_name = to_upper_camel(
-                                "_".join([field_name, plain_name])
-                            )
-                            nested_type.MergeFrom(
-                                descriptor_pb2.DescriptorProto(name=nested_name)
-                            )
-                            for field in nested.field:
-                                if field.type_name == plain_name:
-                                    field.MergeFrom(
-                                        descriptor_pb2.FieldDescriptorProto(
-                                            type_name=nested_name
-                                        )
-                                    )
-                            nested_messages.append(nested_type)
-                        while nested.enum_type:
-                            nested_enum = nested.enum_type.pop()
-                            plain_name = nested_enum.name
-                            nested_name = to_upper_camel(
-                                "_".join([field_name, plain_name])
-                            )
-                            nested_enum.MergeFrom(
-                                descriptor_pb2.EnumDescriptorProto(name=nested_name)
-                            )
-                            for field in nested.field:
-                                if field.type_name == plain_name:
-                                    field.MergeFrom(
-                                        descriptor_pb2.FieldDescriptorProto(
-                                            type_name=nested_name
-                                        )
-                                    )
-                            nested_enums.append(nested_enum)
-
-                # Create the field descriptor
-                field_descriptors.append(
-                    descriptor_pb2.FieldDescriptorProto(**nested_field_kwargs)
-                )
-
-        # If additionalProperties specified, add a 'special' field for this.
-        # This is one place where there's not a good mapping between JTD and
-        # proto since proto does not allow for arbitrary mappings _in addition_
-        # to specific keys. Instead, there needs to be a special Struct field to
-        # hold these additional propreties.
-        if additional_properties:
-            if "additionalProperties" in all_properties:
+    def get_map_key_val_types(
+        self,
+        entry: _JtdDefType,
+    ) -> Optional[Tuple[int, Union[int, _descriptor.Descriptor]]]:
+        """Get the key and value types for a given map type"""
+        values = entry.get("values")
+        if values is not None:
+            string_type = self.type_mapping.get("string")
+            if string_type is None:
                 raise ValueError(
-                    "Cannot specify 'additionalProperties' as a field and use it in the JTD definition"
+                    "Provided type mapping has no key for 'string', so discriminators cannot be used"
                 )
-            field_descriptors.append(
-                descriptor_pb2.FieldDescriptorProto(
-                    name="additionalProperties",
-                    number=len(field_descriptors) + 1,
-                    type=_descriptor.FieldDescriptor.TYPE_MESSAGE,
-                    label=_descriptor.FieldDescriptor.LABEL_OPTIONAL,
-                    type_name=struct_pb2.Struct.DESCRIPTOR.full_name,
-                )
-            )
-            imports.append(struct_pb2.Struct.DESCRIPTOR.file.name)
+            val_type = self._convert(entry=values, name="value")
+            return (string_type, val_type)
 
-        # Support optional properties as oneofs i.e. optional int32 foo = 1;
-        # becomes interpreted as oneof _foo { int32 foo = 1; }
-        optional_oneofs: List[descriptor_pb2.OneofDescriptorProto] = []
-        for field in field_descriptors:
-            if (
-                field.name in optional_properties.keys()
-                and field.label == _descriptor.FieldDescriptor.LABEL_OPTIONAL
-            ):
-                # OneofDescriptorProto do not contain fields themselves. Instead the
-                # FieldDescriptorProto must contain the index of the oneof inside the
-                # DescriptorProto
-                optional_oneofs.append(
-                    descriptor_pb2.OneofDescriptorProto(name=f"_{field.name}")
-                )
-                field.oneof_index = len(nested_oneofs) + len(optional_oneofs) - 1
+    ## Enums ##
 
-        # Construct the message descriptor
-        log.debug3(
-            "All field descriptors for [%s]:\n%s", message_name, field_descriptors
-        )
-        descriptor_proto = descriptor_pb2.DescriptorProto(
-            name=message_name,
-            field=field_descriptors,
-            enum_type=nested_enums,
-            nested_type=nested_messages,
-            oneof_decl=nested_oneofs + optional_oneofs,
-        )
-        return descriptor_proto
+    def get_enum_vals(self, entry: _JtdDefType) -> Optional[List[Tuple[str, int]]]:
+        """Get the ordered list of enum name -> number mappings if this entry is
+        an enum
+
+        NOTE: If any values appear multiple times, this implies an alias
+
+        NOTE 2: All names must be unique
+        """
+        enum = entry.get("enum")
+        if enum is not None:
+            return [
+                (entry_name, entry_idx) for entry_idx, entry_name in enumerate(enum)
+            ]
+
+    ## Messages ##
+
+    def get_message_fields(
+        self,
+        entry: _JtdDefType,
+    ) -> Optional[Iterable[Tuple[str, Any]]]:
+        """Get the mapping of names to type-specific field descriptors"""
+        properties = entry.get("properties", {})
+        optional_properties = entry.get("optionalProperties", {})
+        all_properties = {**properties, **optional_properties}
+        if all_properties:
+            return all_properties.items()
+
+    def has_additional_fields(self, entry: _JtdDefType) -> bool:
+        """Check whether the given entry expects to support arbitrary key/val
+        additional properties
+        """
+        return entry.get("additionalProperties", False)
+
+    def get_optional_field_names(self, entry: _JtdDefType) -> List[str]:
+        """Get the names of any fields which are explicitly marked 'optional'"""
+        return entry.get("optionalProperties", {}).keys()
+
+    ## Fields ##
+
+    def get_field_number(self, num_fields: int, field_def: _JtdDefType) -> int:
+        """If the field has a metadata field "field_number" use that, otherwise,
+        use the next field number sequentially
+        """
+        return field_def.get("metadata", {}).get("field_number", num_fields + 1)
+
+    def get_oneof_fields(
+        self, field_def: _JtdDefType
+    ) -> Optional[Iterable[Tuple[str, Any]]]:
+        """If the given field def is a discriminator, it's a oneof"""
+        discriminator = field_def.get("discriminator")
+        if discriminator is not None:
+            mapping = field_def.get("mapping")
+            assert isinstance(mapping, dict), "Invalid discriminator without mapping"
+            return mapping.items()
+
+    def get_oneof_name(self, field_def: _JtdDefType) -> str:
+        """For an identified oneof field def, get the name"""
+        return field_def.get("discriminator")
+
+    def get_field_type(self, field_def: _JtdDefType) -> Any:
+        """Get the type of the field. The definition of type here will be
+        specific to the converter (e.g. string for JTD, py type for dataclass)
+        """
+        elements = field_def.get("elements")
+        if elements is not None:
+            return elements
+        return field_def
+
+    def is_repeated_field(self, field_def: _JtdDefType) -> bool:
+        """Determine if the given field def is repeated"""
+        return "elements" in field_def

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -149,7 +149,7 @@ class JTDConverter(ConverterBase):
             string_type = self.type_mapping.get("string")
             if string_type is None:
                 raise ValueError(
-                    "Provided type mapping has no key for 'string', so discriminators cannot be used"
+                    "Provided type mapping has no key for 'string', so values maps cannot be used"
                 )
             val_type = self._convert(entry=values, name="value")
             return (string_type, val_type)

--- a/jtd_to_proto/jtd_to_proto.py
+++ b/jtd_to_proto/jtd_to_proto.py
@@ -142,7 +142,7 @@ class JTDConverter(ConverterBase):
     def get_map_key_val_types(
         self,
         entry: _JtdDefType,
-    ) -> Optional[Tuple[int, Union[int, _descriptor.Descriptor]]]:
+    ) -> Optional[Tuple[int, ConverterBase.ConvertOutputTypes]]:
         """Get the key and value types for a given map type"""
         values = entry.get("values")
         if values is not None:

--- a/jtd_to_proto/utils.py
+++ b/jtd_to_proto/utils.py
@@ -1,0 +1,306 @@
+"""
+Common utilities that are shared across converters
+"""
+
+# Standard
+from typing import Any, List
+import re
+
+# Third Party
+from google.protobuf import descriptor_pb2
+import google.protobuf.descriptor_pool
+
+# First Party
+import alog
+
+log = alog.use_channel("2PUTL")
+
+
+def to_upper_camel(snake_str: str) -> str:
+    """Convert a snake_case string to UpperCamelCase"""
+    if not snake_str:
+        return snake_str
+    return (
+        snake_str[0].upper()
+        + re.sub("_([a-zA-Z])", lambda pat: pat.group(1).upper(), snake_str)[1:]
+    )
+
+
+def safe_add_fd_to_pool(
+    fd_proto: descriptor_pb2.FileDescriptorProto,
+    descriptor_pool: google.protobuf.descriptor_pool.DescriptorPool,
+):
+    """Safely add a new file descriptor to a descriptor pool. This function will
+    look for naming collisions and if one occurs, it will validate the inbound
+    descriptor against the conflicting descriptor in the pool to see if they are
+    the same. If they are, no further action is taken. If they are not, an error
+    is raised.
+    """
+    try:
+        existing_fd = descriptor_pool.FindFileByName(fd_proto.name)
+        # Rebuild the file descriptor proto so that we can compare; there is
+        # almost certainly a more efficient way to compare that avoids this.
+        existing_proto = descriptor_pb2.FileDescriptorProto()
+        existing_fd.CopyToProto(existing_proto)
+        # Raise if the file exists already with different content
+        # Otherwise, do not attempt to re-add the file
+        if not _are_same_file_descriptors(fd_proto, existing_proto):
+            # NOTE: This is a TypeError because that is what you get most of the time when you
+            # have conflict issues in the descriptor pool arising from JTD to Proto followed by
+            # importing differing defs for the same top level message type using different file
+            # names (i.e., skipping this validation) compiled by protoc. Raising TypeError here
+            # ensures that we at least usually raise the same error type regardless of
+            # import / operation order.
+            raise TypeError(
+                f"Cannot add new file {fd_proto.name} to descriptor pool, file already exists with different content"
+            )
+    except KeyError:
+        # It's okay for the file to not already exist, we'll add it!
+        try:
+            descriptor_pool.Add(fd_proto)
+        except TypeError as e:
+            # More likely than not, this is a duplicate symbol; the main case in which
+            # this could occur is when you've compiled files with protoc, added them to your
+            # descriptor pool, and ALSO added the defs in your jtd_to_proto schema, but the
+            # lookup validation with fd_proto.name is skipped because the .proto file fed to
+            # protoc had a different name!
+            raise TypeError(
+                f"Failed to add {fd_proto.name} to descriptor pool with error: [{e}]; Hint: if you previously used protoc to compile this definition, you must recompile it with the name {fd_proto.name} to avoid the conflict."
+            )
+
+
+## Implementation Details ######################################################
+
+
+def _are_same_file_descriptors(
+    d1: descriptor_pb2.FileDescriptorProto, d2: descriptor_pb2.FileDescriptorProto
+) -> bool:
+    """Validate that there are no consistency issues in the message descriptors of
+    our proto file descriptors.
+
+    Args:
+        d1: descriptor_pb2.FileDescriptorProto
+            First FileDescriptorProto we want to compare.
+        d2: descriptor_pb2.FileDescriptorProto
+            second FileDescriptorProto we want to compare.
+
+    Returns:
+        True if the provided file descriptor proto files are identical.
+    """
+    have_same_deps = d1.dependency == d2.dependency
+    are_same_package = d1.package == d2.package
+    have_aligned_enums = _are_same_enum_descriptor(d1.enum_type, d2.enum_type)
+    have_aligned_messages = _check_message_descs_alignment(
+        d1.message_type, d2.message_type
+    )
+    have_aligned_services = _check_service_desc_alignment(d1.service, d2.service)
+    return (
+        have_same_deps
+        and are_same_package
+        and have_aligned_enums
+        and have_aligned_messages
+        and have_aligned_services
+    )
+
+
+def _are_same_enum_descriptor(d1_enums: Any, d2_enums: Any) -> bool:
+    """Determine if two iterables of EnumDescriptorProtos have the same enums.
+    This means the following:
+
+    1. They have the same names in their respective .enum_type properties.
+    2. For every enum in enum_type, they have the same number of values & the same names.
+
+    Args:
+        d1_enums: Any
+            First iterable of enum desc protos to compare, e.g., RepeatedCompositeContainer.
+        d2_enums: Any
+            Second iterable of enum desc protos to compare, e.g., RepeatedCompositeContainer.
+
+    Returns:
+        True if the provided iterable enum descriptors are identical.
+    """
+    d1_enum_map = {enum.name: enum for enum in d1_enums}
+    d2_enum_map = {enum.name: enum for enum in d2_enums}
+    if d1_enum_map.keys() != d2_enum_map.keys():
+        return False
+
+    for enum_name in d1_enum_map.keys():
+        d1_enum_descriptor = d1_enum_map[enum_name]
+        d2_enum_descriptor = d2_enum_map[enum_name]
+        if len(d1_enum_descriptor.value) != len(d2_enum_descriptor.value):
+            return False
+        # Compare each entry in the repeated composite container,
+        # i.e., all of our EnumValueDescriptorProto objects
+        for first_enum_val, second_enum_val in zip(
+            d1_enum_descriptor.value, d2_enum_descriptor.value
+        ):
+            if (
+                first_enum_val.name != second_enum_val.name
+                or first_enum_val.number != second_enum_val.number
+            ):
+                return False
+    return True
+
+
+def _check_message_descs_alignment(
+    d1_msg_container: Any, d2_msg_container: Any
+) -> bool:
+    """Determine if two message descriptor proto containers, i.e., RepeatedCompositeContainers
+    have the same message types. This means the following:
+
+    1. The messages contained in each FileDescriptorProto are the same.
+    2. For each of those respective messages, their respective fields are roughly the same.
+       Note that this includes nested_types, which are verified recursively.
+
+    Args:
+        d1_msg_container: Any
+            First container iterable of message descriptors protos to be verified.
+        d2_msg_container: Any
+            Second container iterable of message descriptors protos to be verified.
+
+    Returns:
+        bool
+            True if the contained message descriptor protos are identical.
+    """
+    d1_msg_descs = {msg.name: msg for msg in d1_msg_container}
+    d2_msg_descs = {msg.name: msg for msg in d2_msg_container}
+
+    # Ensure that our descriptors have the same dependencies & top level message types
+    if d1_msg_descs.keys() != d2_msg_descs.keys():
+        return False
+    # For every encapsulated message descriptor, ensure that every field has the same
+    # name, number, label, type, and type name
+    for msg_name in d1_msg_descs.keys():
+        d1_message_descriptor = d1_msg_descs[msg_name]
+        d2_message_descriptor = d2_msg_descs[msg_name]
+        # Ensure that these messages are actually the same
+        if not _are_same_message_descriptor(
+            d1_message_descriptor, d2_message_descriptor
+        ):
+            return False
+    return True
+
+
+def _check_service_desc_alignment(
+    d1_service_list: List[descriptor_pb2.ServiceDescriptorProto],
+    d2_service_list: List[descriptor_pb2.ServiceDescriptorProto],
+) -> bool:
+    d1_service_descs = {svc.name: svc for svc in d1_service_list}
+    d2_service_descs = {svc.name: svc for svc in d2_service_list}
+
+    log.debug(
+        "Checking service descriptors: [%s] and [%s]",
+        d1_service_descs,
+        d2_service_descs,
+    )
+    # Ensure that our service names are the same set
+    if d1_service_descs.keys() != d2_service_descs.keys():
+        # Excluding from code coverage: We can't actually generate file descriptors with multiple services in them.
+        # But, this check seems pretty basic and worth leaving in if this ever gets extended in the future.
+        return False  # pragma: no cover
+
+    # For every service, ensure that every method is the same
+    for svc_name in d1_service_descs.keys():
+        d1_service = d1_service_descs[svc_name]
+        d2_service = d2_service_descs[svc_name]
+
+        if not _are_same_service_descriptor(d1_service, d2_service):
+            return False
+    return True
+
+
+def _are_same_service_descriptor(
+    d1_service: descriptor_pb2.ServiceDescriptorProto,
+    d2_service: descriptor_pb2.ServiceDescriptorProto,
+) -> bool:
+    # Not checking service.name because we only compare services with the same name
+
+    d1_methods = {method.name: method for method in d1_service.method}
+    d2_methods = {method.name: method for method in d2_service.method}
+
+    # Ensure that our service names are the same set
+    if d1_methods.keys() != d2_methods.keys():
+        return False
+
+    # For every service, ensure that every method is the same
+    for method_name in d1_methods.keys():
+        d1_method = d1_methods[method_name]
+        d2_method = d2_methods[method_name]
+
+        if not _are_same_method_descriptor(d1_method, d2_method):
+            return False
+
+    return True
+
+
+def _are_same_method_descriptor(
+    d1_method: descriptor_pb2.MethodDescriptorProto,
+    d2_method: descriptor_pb2.MethodDescriptorProto,
+) -> bool:
+    # Not checking method.name because we only compare services with the same name
+
+    if not _are_types_similar(d1_method.input_type, d2_method.input_type):
+        return False
+    if not _are_types_similar(d1_method.output_type, d2_method.output_type):
+        return False
+    # TODO: Add the ability for `json_to_service` to set options + streaming settings.
+    # Then we can test this!
+    if d1_method.options != d2_method.options:
+        log.debug(  # pragma: no cover
+            "Method options differ! [%s] vs. [%s]", d1_method.options, d2_method.options
+        )
+        return False  # pragma: no cover
+    if d1_method.client_streaming != d2_method.client_streaming:
+        return False  # pragma: no cover
+    if d1_method.server_streaming != d2_method.server_streaming:
+        return False  # pragma: no cover
+    return True
+
+
+def _are_types_similar(type_1: str, type_2: str) -> bool:
+    """Returns true iff type names are the same or differ only by a leading `.`"""
+    # TODO: figure out why when you `json_to_service` the same thing twice, on of the service descriptors ends up with
+    # fully qualified names (.foo.bar.Foo) and the other does not (foo.bar.Foo)
+    return type_1.lstrip(".") == type_2.lstrip(".")
+
+
+def _are_same_message_descriptor(
+    d1: descriptor_pb2.DescriptorProto, d2: descriptor_pb2.DescriptorProto
+) -> bool:
+    """Determine if two message descriptors proto are representing the same thing. We do this by
+    ensuring that their fields all have the same fields, then inspecting each of their labels,
+    names, etc, for alignment. We do the same for any nested fields.
+
+    Args:
+        d1: descriptor_pb2.DescriptorProto
+            First message descriptor to be compared.
+        d2: descriptor_pb2.DescriptorProto
+            second message descriptor to be compared.
+
+    Returns:
+        bool
+            True of messages are identical, False otherwise.
+    """
+    # Compare any nested enums in our message.
+    if not _are_same_enum_descriptor(d1.enum_type, d2.enum_type):
+        return False
+    # Make sure all of our named fields align, then check them individually
+    d1_field_descs = {field.name: field for field in d1.field}
+    d2_field_descs = {field.name: field for field in d2.field}
+    if d1_field_descs.keys() != d2_field_descs.keys():
+        return False
+    for field_name in d1_field_descs.keys():
+        # We consider two fields equal if they have the same name, label
+        d1_field_descriptor = d1_field_descs[field_name]
+        d2_field_descriptor = d2_field_descs[field_name]
+        if (
+            d1_field_descriptor.label != d2_field_descriptor.label
+            or d1_field_descriptor.type != d2_field_descriptor.type
+        ):
+            return False
+    # For nested fields, we treat them similarly to how we've treated messages
+    # and recurse into comparisons used for the top level messages.
+    if d1.nested_type or d2.nested_type:
+        return _check_message_descs_alignment(d1.nested_type, d2.nested_type)
+    # Otherwise, we have no more nested layers to check; we're done!
+    return True

--- a/tests/test_jtd_to_proto.py
+++ b/tests/test_jtd_to_proto.py
@@ -10,7 +10,8 @@ import pytest
 
 # Local
 from jtd_to_proto.json_to_service import json_to_service
-from jtd_to_proto.jtd_to_proto import _to_upper_camel, jtd_to_proto
+from jtd_to_proto.jtd_to_proto import jtd_to_proto
+from jtd_to_proto.utils import to_upper_camel
 
 ## Happy Path ##################################################################
 
@@ -1158,6 +1159,6 @@ def test_protoc_collision_different_def_jtd_to_proto_last(temp_dpool):
 ## Details #####################################################################
 
 
-def test_to_upper_camel_empty():
-    """Make sure _to_upper_camel is safe with an empty string"""
-    assert _to_upper_camel("") == ""
+def testto_upper_camel_empty():
+    """Make sure to_upper_camel is safe with an empty string"""
+    assert to_upper_camel("") == ""


### PR DESCRIPTION
## Description

This PR hoists the core logic out of `jtd_to_proto` into the `ConverterBase` base class and provides hooks where the JTD-specific logic lives. It then reimplements `jtd_to_proto` to be a wrapper around a `JtdConverter` instance.

## Background

It's become clear that the logic here is not limited to converting inbound JTD schemas. In an effort to expand the types of input schemas that can be converted into proto descriptors, we want to keep the skeleton of the `jtd_to_proto` logic while lifting out all of the `jtd`-specific logic. The next target converter will take `dataclass`es and `Enum`s as input to provide a seamless pythonic schema type for creating proto descriptors.